### PR TITLE
Fixed Makefile to detect number of sockets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ config:
 	@echo "Please view Makefile.cosconfig and kernel/include/shared/cpu_ghz.h to make sure they're accurate."
 	@echo "Do _not_ 'git add' either of these files."
 	@cat /proc/cpuinfo | grep "model name" -m 1 | sed 's/.*\([0-9]\.[0-9]*\).*/\#define CPU_GHZ \1/' > ./kernel/include/shared/cpu_ghz.h
-	@cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l | sed 's/.*\([0-9]\).*/\#define NUM_CPU_SOCKETS \1/' >> ./kernel/include/shared/cpu_ghz.h
+	@if [ -z "`cat /proc/cpuinfo | grep \"physical id\"`" ]; then echo "#define NUM_CPU_SOCKETS 1" >> ./kernel/include/shared/cpu_ghz.h; else cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l | sed 's/.*\([0-9]\).*/\#define NUM_CPU_SOCKETS \1/' >> ./kernel/include/shared/cpu_ghz.h; fi
 	@pwd | sed 's/\(\/[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/\).*/HOME_DIR=\1/' > Makefile.cosconfig
 	@echo "CODE_DIR=\$$(HOME_DIR)/research/" >> Makefile.cosconfig
 	@echo "TRANS_DIR=\$$(HOME_DIR)/transfer/" >> Makefile.cosconfig


### PR DESCRIPTION
/proc/cpuinfo contains no infomation about sockets, N_SOCKETS should
be set to 1.
