### PR TITLE
Bugfixes in the scheduling library

### DIFF
--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -67,7 +67,7 @@ cos_init(void)
 
 	cycs = cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE);
 	printc("\t%d cycles per microsecond\n", cycs);
-	sl_init();
+	sl_init(SL_MIN_PERIOD_US);
 
 	for (id = 0; id < VM_COUNT; id ++) {
 		struct cos_compinfo *vm_cinfo = cos_compinfo_get(&(vmx_info[id].dci));

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -872,8 +872,11 @@ test_run_mb(void)
 
 	test_captbl_expand();
 
-//	test_wakeup();
-//	test_preemption();
+	/*
+	 * FIXME: Preemption stack mechanism in the kernel is disabled.
+	 * test_wakeup();
+	 * test_preemption();
+	 */
 }
 
 static void

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -872,8 +872,8 @@ test_run_mb(void)
 
 	test_captbl_expand();
 
-	test_wakeup();
-	test_preemption();
+//	test_wakeup();
+//	test_preemption();
 }
 
 static void

--- a/src/components/implementation/tests/unit_fprr/unit_fprr.c
+++ b/src/components/implementation/tests/unit_fprr/unit_fprr.c
@@ -127,7 +127,7 @@ cos_init(void)
 	printc("Unit-test for the scheduling library (sl)\n");
 	cos_meminfo_init(&(ci->mi), BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
 	cos_defcompinfo_init();
-	sl_init();
+	sl_init(SL_MIN_PERIOD_US);
 
 	testing_thread = sl_thd_alloc(run_tests, NULL);
 	sl_thd_param_set(testing_thread, sched_param_pack(SCHEDP_PRIO, LOWEST_PRIORITY));

--- a/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
+++ b/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
@@ -149,7 +149,7 @@ cos_init(void)
 	printc("Unit-test for the scheduling library (sl)\n");
 	cos_meminfo_init(&(ci->mi), BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
 	cos_defcompinfo_init();
-	sl_init();
+	sl_init(SL_MIN_PERIOD_US);
 
 	//	test_yields();
 	//	test_blocking_directed_yield();

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -462,6 +462,13 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 	sl_cs_exit();
 
 	ret = sl_thd_activate(t, tok);
+	/*
+	 * dispatch failed with -EPERM because tcap associated with thread t does not have budget.
+	 * Block the thread until it's next replenishment and return to the scheduler thread.
+	 *
+	 * If the thread is not replenished by the scheduler (replenished "only" by 
+	 * the inter-component delegations), block till next timeout and try again.
+	 */
 	if (unlikely(ret == -EPERM)) {
 			cycles_t abs_timeout = globals->timer_next;
 

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -63,6 +63,8 @@ struct sl_global {
 	cycles_t    period;
 	cycles_t    timer_next;
 	tcap_time_t timeout_next;
+
+	struct ps_list_head event_head; /* all pending events for sched end-point */
 };
 
 extern struct sl_global sl_global_data;

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -449,7 +449,7 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 		}
 	}
 
-	assert(t->state == SL_THD_RUNNABLE || t->state == SL_THD_WOKEN);
+	assert(t->state == SL_THD_RUNNABLE);
 	sl_cs_exit();
 
 	/* TODO: handle `-EPERM` in cos_switch() to interrupt thread or cos_asnd to child comp with its own tcap here. */

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -407,6 +407,7 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 	sched_tok_t           tok;
 	cycles_t              now;
 	s64_t                 offset;
+	int                   ret;
 
 	/* Don't abuse this, it is only to enable the tight loop around this function for races... */
 	if (unlikely(!sl_cs_owner())) sl_cs_enter();
@@ -438,22 +439,41 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 
 	if (t->properties & SL_THD_PROPERTY_OWN_TCAP) {
 		assert(t->budget && t->period);
+		assert(sl_thd_tcap(t) != sl__globals()->sched_tcap);
 
 		if (t->last_replenish == 0 || t->last_replenish + t->period <= now) {
-			tcap_res_t currbudget;
+			tcap_res_t currbudget = 0;
+			cycles_t replenish    = now - ((now - t->last_replenish) % t->period);  
 
-			t->last_replenish = now;
-			currbudget        = (tcap_res_t)cos_introspect(ci, sl_thd_tcap(t), TCAP_GET_BUDGET);
-			/* TODO: need to change logic for SNDCAP with tcap_delegate, and error handling */
-			if (currbudget < t->budget && cos_tcap_transfer(sl_thd_rcvcap(t), sl__globals()->sched_tcap, (t->budget - currbudget), t->prio)) assert(0);
+			ret = 0;
+			if (likely(t->last_replenish)) currbudget = (tcap_res_t)cos_introspect(ci, sl_thd_tcap(t), TCAP_GET_BUDGET);
+
+			if (!cycles_same(currbudget, t->budget, SL_CYCS_DIFF) && currbudget < t->budget) {
+				tcap_res_t transfer = t->budget - currbudget;
+
+				ret = cos_tcap_transfer(sl_thd_rcvcap(t), sl__globals()->sched_tcap, transfer, t->prio);
+			}
+
+			if (likely(ret == 0)) t->last_replenish = replenish;
 		}
 	}
 
 	assert(t->state == SL_THD_RUNNABLE);
 	sl_cs_exit();
 
-	/* TODO: handle `-EPERM` in cos_switch() to interrupt thread or cos_asnd to child comp with its own tcap here. */
-	return sl_thd_activate(t, tok);
+	ret = sl_thd_activate(t, tok);
+	if (unlikely(ret == -EPERM)) {
+			cycles_t abs_timeout = t->last_replenish + t->period;
+
+			assert(t != globals->sched_thd);
+			assert(t->properties & SL_THD_PROPERTY_OWN_TCAP);
+
+			sl_thd_block_no_cs(t, SL_THD_BLOCKED_TIMEOUT, abs_timeout);
+
+			if (unlikely(sl_thd_curr() != globals->sched_thd)) ret = sl_thd_activate(globals->sched_thd, tok);
+	}
+
+	return ret;
 }
 
 static inline int

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -508,12 +508,12 @@ sl_cs_exit_switchto(struct sl_thd *to)
  * library-internal data-structures, and then the ability for the
  * scheduler thread to start its scheduling loop.
  *
- * sl_init();
+ * sl_init(period); <- using `period` for scheduler periodic timeouts 
  * sl_*;            <- use the sl_api here
  * ...
  * sl_sched_loop(); <- loop here
  */
-void sl_init(void);
+void sl_init(microsec_t period);
 void sl_sched_loop(void);
 
 #endif /* SL_H */

--- a/src/components/include/sl_consts.h
+++ b/src/components/include/sl_consts.h
@@ -1,7 +1,8 @@
 #ifndef SL_CONSTS
 #define SL_CONSTS
 
-#define SL_PERIOD_US 1000
+#define SL_PERIOD_US    1000
 #define SL_MAX_NUM_THDS MAX_NUM_THREADS
+#define SL_CYCS_DIFF    (1<<14)
 
 #endif /* SL_CONSTS */

--- a/src/components/include/sl_consts.h
+++ b/src/components/include/sl_consts.h
@@ -1,8 +1,8 @@
 #ifndef SL_CONSTS
 #define SL_CONSTS
 
-#define SL_PERIOD_US    1000
-#define SL_MAX_NUM_THDS MAX_NUM_THREADS
-#define SL_CYCS_DIFF    (1<<14)
+#define SL_MIN_PERIOD_US 1000
+#define SL_MAX_NUM_THDS  MAX_NUM_THREADS
+#define SL_CYCS_DIFF     (1<<14)
 
 #endif /* SL_CONSTS */

--- a/src/components/include/sl_plugins.h
+++ b/src/components/include/sl_plugins.h
@@ -16,6 +16,14 @@
  */
 struct sl_thd_policy *sl_thd_alloc_backend(thdid_t tid);
 void                  sl_thd_free_backend(struct sl_thd_policy *t);
+/*
+ * cos_aep_info structs cannot be stack allocated!
+ * The thread_alloc_backened needs to provide struct cos_aep_info without
+ * any knowledge of the thread being alloced.
+ *
+ * sl_thd_free_backend to free the cos_aep_info struct
+ */
+struct cos_aep_info  *sl_thd_alloc_aep_backend(void);
 
 void                  sl_thd_index_add_backend(struct sl_thd_policy *);
 void                  sl_thd_index_rem_backend(struct sl_thd_policy *);

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -25,13 +25,13 @@ typedef enum {
 } sl_thd_property_t;
 
 struct sl_thd {
-	sl_thd_state_t      state;
-	sl_thd_property_t   properties;
-	thdid_t             thdid;
-	struct cos_aep_info aepinfo;
-	asndcap_t           sndcap;
-	tcap_prio_t         prio;
-	struct sl_thd      *dependency;
+	sl_thd_state_t       state;
+	sl_thd_property_t    properties;
+	thdid_t              thdid;
+	struct cos_aep_info *aepinfo;
+	asndcap_t            sndcap;
+	tcap_prio_t          prio;
+	struct sl_thd       *dependency;
 
 	tcap_res_t budget;        /* budget if this thread has it's own tcap */
 	cycles_t   last_replenish;
@@ -44,7 +44,7 @@ struct sl_thd {
 
 static inline struct cos_aep_info *
 sl_thd_aepinfo(struct sl_thd *t)
-{ return &(t->aepinfo); }
+{ return (t->aepinfo); }
 
 static inline thdcap_t
 sl_thd_thdcap(struct sl_thd *t)

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -14,7 +14,7 @@ typedef enum {
 	SL_THD_FREE = 0,
 	SL_THD_BLOCKED,
 	SL_THD_BLOCKED_TIMEOUT,
-	SL_THD_WOKEN, /* if a race causes a wakeup before the inevitable block */
+	SL_THD_WOKEN, /* Unused because kernel may send redundant scheduling events! if a race causes a wakeup before the inevitable block */
 	SL_THD_RUNNABLE,
 	SL_THD_DYING,
 } sl_thd_state_t;

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -8,7 +8,10 @@
 #ifndef SL_THD_H
 #define SL_THD_H
 
+#include <ps.h>
 #include <cos_debug.h>
+
+#define SL_THD_EVENT_LIST event_list
 
 typedef enum {
 	SL_THD_FREE = 0,
@@ -23,6 +26,12 @@ typedef enum {
 	SL_THD_PROPERTY_OWN_TCAP = 1,      /* Thread owns a tcap */
 	SL_THD_PROPERTY_SEND     = (1<<1), /* use asnd to dispatch to this thread */
 } sl_thd_property_t;
+
+struct event_info {
+	int         blocked; /* 1 - blocked. 0 - awoken */
+	cycles_t    cycles;
+	tcap_time_t timeout;
+};
 
 struct sl_thd {
 	sl_thd_state_t       state;
@@ -40,6 +49,9 @@ struct sl_thd {
 	cycles_t   timeout_cycs;  /* next timeout - used in timeout API */
 	cycles_t   wakeup_cycs;   /* actual last wakeup - used in timeout API for jitter information, etc */
 	int        timeout_idx;   /* timeout heap index, used in timeout API */
+
+	struct event_info event_info;
+	struct ps_list    SL_THD_EVENT_LIST; /* list of events for the scheduler end-point */
 };
 
 static inline struct cos_aep_info *

--- a/src/components/lib/cos_defkernel_api.c
+++ b/src/components/lib/cos_defkernel_api.c
@@ -47,8 +47,6 @@ void
 cos_defcompinfo_init_ext(tcap_t sched_tc, thdcap_t sched_thd, arcvcap_t sched_rcv, pgtblcap_t pgtbl_cap,
                          captblcap_t captbl_cap, compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier)
 {
-	assert(curr_defci_init_status == UNINITIALIZED);
-
 	struct cos_defcompinfo *defci     = cos_defcompinfo_curr_get();
 	struct cos_compinfo *   ci        = cos_compinfo_get(defci);
 	struct cos_aep_info *   sched_aep = cos_sched_aep_get(defci);

--- a/src/components/lib/posix/posix.c
+++ b/src/components/lib/posix/posix.c
@@ -264,7 +264,7 @@ pre_syscall_default_setup()
 
 	cos_defcompinfo_init();
 	cos_meminfo_init(&(ci->mi), BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
-	sl_init();
+	sl_init(SL_MIN_PERIOD_US);
 }
 
 void

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -377,6 +377,7 @@ sl_thd_aep_alloc_intern(cos_aepthd_fn_t fn, void *data, struct cos_defcompinfo *
 
 		assert(comp);
 		sa   = cos_sched_aep_get(comp);
+		/* copying cos_aep_info is fine here as cos_thd_alloc() is not done using this aep */
 		*aep = *sa;
 
 		snd = cos_asnd_alloc(ci, aep->rcv, ci->captbl_cap);
@@ -442,6 +443,7 @@ sl_thd_comp_init(struct cos_defcompinfo *comp, int is_sched)
 		aep = sl_thd_alloc_aep_backend();
 		if (!aep) goto done;
 
+		/* copying cos_aep_info is fine here as cos_thd_alloc() is not done using this aep */
 		*aep = *sa;
 		tid = cos_introspect(ci, aep->thd, THD_GET_TID);
 		assert(tid);

--- a/src/components/lib/sl/sl_mod_fprr.c
+++ b/src/components/lib/sl/sl_mod_fprr.c
@@ -7,7 +7,7 @@
 #define SL_FPRR_PRIO_HIGHEST   0
 #define SL_FPRR_PRIO_LOWEST    (SL_FPRR_NPRIOS-1)
 
-#define SL_FPRR_PERIOD_US_MIN  SL_PERIOD_US
+#define SL_FPRR_PERIOD_US_MIN  SL_MIN_PERIOD_US
 
 struct ps_list_head threads[SL_FPRR_NPRIOS];
 
@@ -111,6 +111,7 @@ sl_mod_init(void)
 {
 	int i;
 
+	memset(threads, 0, sizeof(struct ps_list_head) * SL_FPRR_NPRIOS);
 	for (i = 0 ; i < SL_FPRR_NPRIOS ; i++) {
 		ps_list_head_init(&threads[i]);
 	}

--- a/src/components/lib/sl/sl_thd_static_backend.c
+++ b/src/components/lib/sl/sl_thd_static_backend.c
@@ -11,9 +11,9 @@
 #include <cos_kernel_api.h>
 #include <cos_defkernel_api.h>
 
-static struct sl_thd_policy sl_threads[SL_MAX_NUM_THDS];
+static struct sl_thd_policy __sl_threads[SL_MAX_NUM_THDS];
 
-static struct cos_aep_info __sl_aep_info[SL_MAX_NUM_THDS];
+static struct cos_aep_info __sl_aep_infos[SL_MAX_NUM_THDS];
 static u32_t               __sl_aep_free_off;
 
 /* Default implementations of backend functions */
@@ -21,7 +21,7 @@ struct sl_thd_policy *
 sl_thd_alloc_backend(thdid_t tid)
 {
 	assert(tid < SL_MAX_NUM_THDS);
-	return &sl_threads[tid];
+	return &__sl_threads[tid];
 }
 
 struct cos_aep_info *
@@ -30,8 +30,8 @@ sl_thd_alloc_aep_backend(void)
 	struct cos_aep_info *aep = NULL;
 
 	assert(__sl_aep_free_off < SL_MAX_NUM_THDS);
-	aep = &__sl_aep_info[__sl_aep_free_off];
-	__sl_aep_free_off ++;
+	aep = &__sl_aep_infos[__sl_aep_free_off];
+	__sl_aep_free_off++;
 
 	return aep;
 }
@@ -52,7 +52,7 @@ struct sl_thd_policy *
 sl_thd_lookup_backend(thdid_t tid)
 {
 	assert(tid < SL_MAX_NUM_THDS);
-	return &sl_threads[tid];
+	return &__sl_threads[tid];
 }
 
 void
@@ -60,7 +60,7 @@ sl_thd_init_backend(void)
 {
 	assert(SL_MAX_NUM_THDS <= MAX_NUM_THREADS);
 
-	memset(sl_threads, 0, sizeof(struct sl_thd_policy)*SL_MAX_NUM_THDS);
-	memset(__sl_aep_info, 0, sizeof(struct cos_aep_info)*SL_MAX_NUM_THDS);
+	memset(__sl_threads, 0, sizeof(struct sl_thd_policy)*SL_MAX_NUM_THDS);
+	memset(__sl_aep_infos, 0, sizeof(struct cos_aep_info)*SL_MAX_NUM_THDS);
 	__sl_aep_free_off = 0;
 }

--- a/src/components/lib/sl/sl_thd_static_backend.c
+++ b/src/components/lib/sl/sl_thd_static_backend.c
@@ -9,8 +9,12 @@
 #include <consts.h>
 #include <ps.h>
 #include <cos_kernel_api.h>
+#include <cos_defkernel_api.h>
 
 static struct sl_thd_policy sl_threads[SL_MAX_NUM_THDS];
+
+static struct cos_aep_info __sl_aep_info[SL_MAX_NUM_THDS];
+static u32_t               __sl_aep_free_off;
 
 /* Default implementations of backend functions */
 struct sl_thd_policy *
@@ -18,6 +22,18 @@ sl_thd_alloc_backend(thdid_t tid)
 {
 	assert(tid < SL_MAX_NUM_THDS);
 	return &sl_threads[tid];
+}
+
+struct cos_aep_info *
+sl_thd_alloc_aep_backend(void)
+{
+	struct cos_aep_info *aep = NULL;
+
+	assert(__sl_aep_free_off < SL_MAX_NUM_THDS);
+	aep = &__sl_aep_info[__sl_aep_free_off];
+	__sl_aep_free_off ++;
+
+	return aep;
 }
 
 void
@@ -41,4 +57,10 @@ sl_thd_lookup_backend(thdid_t tid)
 
 void
 sl_thd_init_backend(void)
-{ assert(SL_MAX_NUM_THDS <= MAX_NUM_THREADS); }
+{
+	assert(SL_MAX_NUM_THDS <= MAX_NUM_THREADS);
+
+	memset(sl_threads, 0, sizeof(struct sl_thd_policy)*SL_MAX_NUM_THDS);
+	memset(__sl_aep_info, 0, sizeof(struct cos_aep_info)*SL_MAX_NUM_THDS);
+	__sl_aep_free_off = 0;
+}

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -538,11 +538,12 @@ asnd_process(struct thread *rcv_thd, struct thread *thd, struct tcap *rcv_tcap, 
 
 	/*
 	 * FIXME: Need to revisit the preemption-stack functionality
+	 *
+	 * if (next == thd)
+	 * 	tcap_wakeup(rcv_tcap, tcap_sched_info(rcv_tcap)->prio, 0, rcv_thd, cos_info);
+	 * else
+	 * 	thd_next_thdinfo_update(cos_info, thd, tcap, tcap_sched_info(tcap)->prio, 0);
 	 */
-	//if (next == thd)
-	//	tcap_wakeup(rcv_tcap, tcap_sched_info(rcv_tcap)->prio, 0, rcv_thd, cos_info);
-	//else
-	//	thd_next_thdinfo_update(cos_info, thd, tcap, tcap_sched_info(tcap)->prio, 0);
 
 	return next;
 }

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -547,10 +547,13 @@ asnd_process(struct thread *rcv_thd, struct thread *thd, struct tcap *rcv_tcap, 
 	thd_rcvcap_pending_inc(rcv_thd);
 	next = notify_process(rcv_thd, thd, rcv_tcap, tcap, tcap_next, yield);
 
-	if (next == thd)
-		tcap_wakeup(rcv_tcap, tcap_sched_info(rcv_tcap)->prio, 0, rcv_thd, cos_info);
-	else
-		thd_next_thdinfo_update(cos_info, thd, tcap, tcap_sched_info(tcap)->prio, 0);
+	/*
+	 * FIXME: Need to revisit the preemption-stack functionality
+	 */
+	//if (next == thd)
+	//	tcap_wakeup(rcv_tcap, tcap_sched_info(rcv_tcap)->prio, 0, rcv_thd, cos_info);
+	//else
+	//	thd_next_thdinfo_update(cos_info, thd, tcap, tcap_sched_info(tcap)->prio, 0);
 
 	return next;
 }

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -485,16 +485,6 @@ notify_parent(struct thread *rcv_thd, int send)
 	prev_notif = rcv_thd;
 	curr_notif = arcv_notif = arcv_thd_notif(prev_notif);
 
-	/*
-	 * Enqueue send sched event only if it's the first one after the thread
-	 * state changed to THD_STATE_RCVING.
-	 * This is to avoid duplicate wakeup events at user-level scheduling.
-	 * Basically changing to Edge-triggered wakeup notification from 
-	 * some form of level-triggered.
-	 */ 
-	if (send && (!(rcv_thd->state & THD_STATE_RCVING) || 
-	    (rcv_thd->state & THD_STATE_RCVING && thd_rcvcap_pending(rcv_thd)))) goto done;
-
 	while (curr_notif && curr_notif != prev_notif) {
 		assert(depth < ARCV_NOTIF_DEPTH);
 
@@ -506,7 +496,6 @@ notify_parent(struct thread *rcv_thd, int send)
 		depth++;
 	}
 
-done:
 	return arcv_notif;
 }
 
@@ -566,13 +555,12 @@ cap_update(struct pt_regs *regs, struct thread *thd_curr, struct thread *thd_nex
 	struct thread *thc, *thn;
 	struct tcap *  tc, *tn;
 	cycles_t       now;
-	int            budget_expired = 0, switch_away = 0;
+	int            switch_away = 0;
 
 	/* which tcap should we use?  is the current expended? */
 	if (tcap_budgets_update(cos_info, thd_curr, tc_curr, &now)) {
 		assert(!tcap_is_active(tc_curr) && tcap_expended(tc_curr));
 
-		budget_expired = 1;
 		if (timer_intr_context) tc_next= thd_rcvcap_tcap(thd_next);
 
 		/* how about the scheduler's tcap? */
@@ -598,8 +586,7 @@ cap_update(struct pt_regs *regs, struct thread *thd_curr, struct thread *thd_nex
 		/* tc_next is tc_curr */
 	}
 
-	if (unlikely(budget_expired)) notify_parent(tcap_rcvcap_thd(tc_curr), 0);
-	if (unlikely(switch_away)) thd_next = notify_process(thd_next, thd_curr, tc_next, tc_curr, &tc_next, 1);
+	if (unlikely(switch_away)) notify_parent(thd_next, 1);
 
 	/* update tcaps, and timers */
 	tcap_timer_update(cos_info, tc_next, timeout, now);
@@ -884,6 +871,7 @@ cap_arcv_op(struct cap_arcv *arcv, struct thread *thd, struct pt_regs *regs, str
 
 		return 0;
 	}
+	__userregs_setretvals(regs, 0, 0, 0, 0);
 
 	next = notify_parent(thd, 0);
 	/* TODO: should we continue tcap-inheritence policy in this case? */


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Many of the changes are a result of debugging in `rump2cos` env and I figured it is useful to merge asap as it includes fundamental parts of the `sl` like `sl_thd_aep_alloc()` bug.

Major changes:
**sched lib:**
* Fixed tcap budget management and handle `-EPERM` (no budget with tcap) from dispatch functionality
* Removed SL_THD_WOKEN state and allow redundant scheduling events
* fixed sl_thd_aep_alloc() functions to use static cos_aep_info structs!
* changed sl_init() to allow period to be passed for hierarchical timeout granularities.
* fixed a bug related to dropping of scheduling events in `sl_sched_loop`. [This was detected from static analysis of the code and not from any test.]

**kernel:**
* undo redundant scheduling events for asnds and removed budget expiry events - perhaps revisit this
* disable preemption-stack code - need to revisit
* a bug in `cos_sched_rcv` for root scheduler because root scheduler doesn't really get suspend, output values were garbage because of register reuse in this system call.
* a bug when tcap expended logic decided to resume execution of the same "scheduler" thread from cos_sched_rcv, the registers were not restored correctly. 

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- micro_booter, vkernel_boot, unit_fprr, unit_schedtests, unit_defci
- tested in rump2cos env (where bugs were originally uncovered!)
