### PR TITLE
Bugfix in ps usage for sl, optimized tcap_higher_prio and fixed asnd/rcv test in micro_booter

### DIFF
--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -325,8 +325,10 @@ sl_thd_event_enqueue(struct sl_thd *t, int blocked, cycles_t cycles, tcap_time_t
 }
 
 static inline void
-sl_thd_event_info(struct sl_thd *t, int *blocked, cycles_t *cycles, tcap_time_t *timeout)
+sl_thd_event_dequeue(struct sl_thd *t, int *blocked, cycles_t *cycles, tcap_time_t *timeout)
 {
+	ps_list_rem(t, SL_THD_EVENT_LIST);
+
 	*blocked = t->event_info.blocked;
 	*cycles  = t->event_info.cycles;
 	*timeout = t->event_info.timeout;
@@ -605,7 +607,7 @@ sl_sched_loop(void)
 			int            blocked, rcvd;
 			cycles_t       cycles;
 			tcap_time_t    timeout = g->timeout_next, thd_timeout;
-			struct sl_thd *t, *tn;
+			struct sl_thd *t = NULL, *tn = NULL;
 
 			/*
 			 * a child scheduler may receive both scheduling notifications (block/unblock
@@ -631,7 +633,7 @@ sl_sched_loop(void)
 			sl_thd_event_enqueue(t, blocked, cycles, thd_timeout);
 
 pending_events:
-			if (ps_list_is_head(&g->event_head, t, SL_THD_EVENT_LIST)) continue;
+			if (ps_list_head_empty(&g->event_head)) continue;
 
 			/*
 			 * receiving scheduler notifications is not in critical section mainly for
@@ -643,10 +645,12 @@ pending_events:
 			if (sl_cs_enter_sched()) continue;
 
 			ps_list_foreach_del(&g->event_head, t, tn, SL_THD_EVENT_LIST) {
+				/* remove the event from the list and get event info */
+				sl_thd_event_dequeue(t, &blocked, &cycles, &thd_timeout);
+
 				/* outdated event for a freed thread */
 				if (t->state == SL_THD_FREE) continue;
 
-				sl_thd_event_info(t, &blocked, &cycles, &thd_timeout);
 				sl_mod_execution(sl_mod_thd_policy_get(t), cycles);
 
 				if (blocked) {

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -631,7 +631,7 @@ sl_sched_loop(void)
 			sl_thd_event_enqueue(t, blocked, cycles, thd_timeout);
 
 pending_events:
-			if (!ps_list_head_first(&g->event_head, struct sl_thd, SL_THD_EVENT_LIST)) continue;
+			if (ps_list_is_head(&g->event_head, t, SL_THD_EVENT_LIST)) continue;
 
 			/*
 			 * receiving scheduler notifications is not in critical section mainly for

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -281,6 +281,7 @@ tcap_higher_prio(struct tcap *a, struct tcap *c)
 	int ret = 0;
 
 	if (tcap_expended(a)) return 0;
+	if (unlikely(a == c)) return 1;
 
 	for (i = 0, j = 0; i < a->ndelegs && j < c->ndelegs;) {
 		/*


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Fixes & changes:
KERNEL:
* optimized `tcap_higher_prio` to return immediately if both tcaps are same, return 1 to preempt the current. 

SCHEDLIB:
* bugfix in ps library usage - use ps_list_is_head to check if there are no items in the list.

MICROBOOTER:
* fixed asnd/rcv unit test case, parent must be higher and child must be lower for the test we have in there.  It worked because of preemption stack feature mainly.  I'm sorry I missed the error in the test output somehow!

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- micro_booter, vkernel_booter, unit_schedtest, unit_fprr, unit_defci
- also hierarchical sl scheduling in rump2cos.
