### PR TITLE
Bugfixes in the kernel, changed sl to allow NON_BLOCKING sched_rcv 

### DIFF
--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -122,7 +122,7 @@ cos_init(void)
 	printc("Starting Scheduler\n");
 	printc("------------------[ VKernel & VMs init complete ]------------------\n");
 
-	sl_sched_loop();
+	sl_sched_loop(SL_SCHEDRCV_DEFAULT);
 
 	printc("vkernel: END\n");
 	cos_thd_switch(vk_info.termthd);

--- a/src/components/implementation/tests/unit_fprr/unit_fprr.c
+++ b/src/components/implementation/tests/unit_fprr/unit_fprr.c
@@ -132,7 +132,7 @@ cos_init(void)
 	testing_thread = sl_thd_alloc(run_tests, NULL);
 	sl_thd_param_set(testing_thread, sched_param_pack(SCHEDP_PRIO, LOWEST_PRIORITY));
 
-	sl_sched_loop();
+	sl_sched_loop(SL_SCHEDRCV_DEFAULT);
 
 	assert(0);
 

--- a/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
+++ b/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
@@ -155,7 +155,7 @@ cos_init(void)
 	//	test_blocking_directed_yield();
 	test_timeout_wakeup();
 
-	sl_sched_loop();
+	sl_sched_loop(SL_SCHEDRCV_DEFAULT);
 
 	assert(0);
 

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -528,6 +528,6 @@ sl_cs_exit_switchto(struct sl_thd *to)
  * sl_sched_loop(); <- loop here
  */
 void sl_init(microsec_t period);
-void sl_sched_loop(void);
+void sl_sched_loop(int non_block);
 
 #endif /* SL_H */

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -363,14 +363,16 @@ sl_thd_activate(struct sl_thd *t, sched_tok_t tok)
 {
 	struct cos_defcompinfo *dci = cos_defcompinfo_curr_get();
 	struct cos_compinfo    *ci  = &dci->ci;
+	struct sl_global       *g   = sl__globals();
 
 	if (t->properties & SL_THD_PROPERTY_SEND) {
-		return cos_sched_asnd(t->sndcap, sl__globals()->timeout_next, sl__globals()->sched_rcv, tok);
+		return cos_sched_asnd(t->sndcap, g->timeout_next, g->sched_rcv, tok);
 	} else if (t->properties & SL_THD_PROPERTY_OWN_TCAP) {
 		return cos_switch(sl_thd_thdcap(t), sl_thd_tcap(t), t->prio,
-				  sl__globals()->timeout_next, sl__globals()->sched_rcv, tok);
+				  g->timeout_next, g->sched_rcv, tok);
 	} else {
-		return cos_defswitch(sl_thd_thdcap(t), t->prio, sl__globals()->timeout_next, tok);
+		return cos_defswitch(sl_thd_thdcap(t), t->prio, t == g->sched_thd ? 
+				     TCAP_TIME_NIL : g->timeout_next, tok);
 	}
 }
 

--- a/src/components/include/sl_consts.h
+++ b/src/components/include/sl_consts.h
@@ -1,8 +1,9 @@
 #ifndef SL_CONSTS
 #define SL_CONSTS
 
-#define SL_MIN_PERIOD_US 1000
-#define SL_MAX_NUM_THDS  MAX_NUM_THREADS
-#define SL_CYCS_DIFF     (1<<14)
+#define SL_MIN_PERIOD_US    1000
+#define SL_MAX_NUM_THDS     MAX_NUM_THREADS
+#define SL_CYCS_DIFF        (1<<14)
+#define SL_SCHEDRCV_DEFAULT 0 /* cos_sched_rcv in sl_sched_loop be BLOCKING by DEFAULT. booter/root RCV end-point doesn't block anyway! */
 
 #endif /* SL_CONSTS */

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -31,7 +31,8 @@ sl_cs_enter_contention(union sl_cs_intern *csi, union sl_cs_intern *cached, thdc
 		if (!ps_cas(&g->lock.u.v, cached->v, csi->v)) return 1;
 	}
 	/* Switch to the owner of the critical section, with inheritance using our tcap/priority */
-	if ((ret = cos_defswitch(csi->s.owner, t->prio, g->timeout_next, tok))) return ret;
+	if ((ret = cos_defswitch(csi->s.owner, t->prio, csi->s.owner == sl_thd_thdcap(g->sched_thd) ? 
+				 TCAP_TIME_NIL : g->timeout_next, tok))) return ret;
 	/* if we have an outdated token, then we want to use the same repeat loop, so return to that */
 
 	return 1;
@@ -46,7 +47,7 @@ sl_cs_exit_contention(union sl_cs_intern *csi, union sl_cs_intern *cached, sched
 
 	if (!ps_cas(&g->lock.u.v, cached->v, 0)) return 1;
 	/* let the scheduler thread decide which thread to run next, inheriting our budget/priority */
-	cos_defswitch(g->sched_thdcap, t->prio, g->timeout_next, tok);
+	cos_defswitch(g->sched_thdcap, t->prio, TCAP_TIME_NIL, tok);
 
 	return 0;
 }

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -562,6 +562,8 @@ cap_update(struct pt_regs *regs, struct thread *thd_curr, struct thread *thd_nex
 	if (tcap_budgets_update(cos_info, thd_curr, tc_curr, &now)) {
 		assert(!tcap_is_active(tc_curr) && tcap_expended(tc_curr));
 
+		/* can't use timeout on another tcap */
+		timeout = 0;
 		if (timer_intr_context) tc_next= thd_rcvcap_tcap(thd_next);
 
 		/* how about the scheduler's tcap? */

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -550,7 +550,7 @@ thd_rcvcap_pending_deliver(struct thread *thd, struct pt_regs *regs)
 static inline int
 thd_switch_update(struct thread *thd, struct pt_regs *regs, int issame)
 {
-	int preempt = 0, issamercv = 0;
+	int preempt = 0;
 
 	/* TODO: check FPU */
 	/* fpu_save(thd); */
@@ -568,10 +568,9 @@ thd_switch_update(struct thread *thd, struct pt_regs *regs, int issame)
 		 * and budget expended logic decided to run the scheduler thread with it's
 		 * tcap, then curr_thd == next_thd and state will be RCVING.
 		 */
-		if (unlikely(issame)) issamercv = 1;
 	}
 
-	if (issame || issamercv) {
+	if (issame && preempt == 0) {
 		__userregs_set(regs, 0, __userregs_getsp(regs), __userregs_getip(regs));
 	}
 


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Major changes:
KERNEL:
* Fixed a problem where timeout was set when we change the tcap and switch to parent or another scheduler. This is a TODO for child scheds abiding by parent timeout rules, but for now, we don't have it.
* A problem with restoring registers which I honestly complicated with confusing conditions before. Fixed that.

SL LIB:
* Allow `sl_sched_loop` to use `NON_BLOCKING` in `cos_sched_rcv`. I feel like the naming in `SL_SCHEDRCV_DEFAULT` is not great. 
* Setting timeouts for `cos_defswitch()` when switching to the scheduler is not necessary. In fact, it was causing RK scheduler to switch to chronos even though RK had INF budget. Fixed that!

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- microbooter, unitschedtest, unit fprr
- rump2cos env where most of these bugs are found.
