### PR TITLE
Add some missing flags to build on x64

### DIFF
--- a/src/components/implementation/Makefile.subsubdir
+++ b/src/components/implementation/Makefile.subsubdir
@@ -74,7 +74,7 @@ $(COMPONENT): $(OBJS)
 #	$(info |     [LD]   $@: Loading stubs and cos libraries $(if $(strip $(LIB_LIBRARIES)),including $(LIB_LIBRARIES)) into $<)
 	$(info |     [LD]   $(COMPNAME) ($@): Linking $(if $(strip $(LIB_LIBRARIES)),$(LIB_LIBRARIES)) $^)
 	@$(LD) $(LDFLAGS) -r -o $@.$(TMP_STR) $^ $(IF_SERV_STUBS) $(IF_CLIENT_STUBS) $(LIB_ASM_MANDITORY) $(LIB_FLAGS)
-	@$(MUSLCC) $@.$(TMP_STR) $(MUSLCFLAGS) -Xlinker -r -o $@.$(TMP_STR2)
+	@$(MUSLCC) $@.$(TMP_STR) $(MUSLCFLAGS) -Wl,-melf_i386 -Xlinker -r -o $@.$(TMP_STR2)
 	@$(LD) $(LDFLAGS) -r -T $(COMP_LD_SCRIPT) -o $@ $@.$(TMP_STR2)
 	@rm $@.$(TMP_STR) $@.$(TMP_STR2)
 	@cp $@ c.o

--- a/src/components/lib/Makefile
+++ b/src/components/lib/Makefile
@@ -51,7 +51,7 @@ distclean:
 	make -C libcxx clean
 
 musl:
-	cd musl-1.1.11; ./configure --disable-shared --enable-debug; cd ..
+	cd musl-1.1.11; ./configure --disable-shared --enable-debug CFLAGS='-m32 -Wl,-melf_i386' LDFLAGS='-Wl,-melf_i386' i386; cd ..
 	make -C musl-1.1.11
 	make -C musl-1.1.11 install
 

--- a/src/components/lib/libcxx/libstdc++-v3-4.8/Makefile.inc
+++ b/src/components/lib/libcxx/libstdc++-v3-4.8/Makefile.inc
@@ -1,4 +1,4 @@
 CXX := g++
 AR := ar
 MV := mv
-CXXFLAGS := -Wall -nostdinc -nostdlib -fno-stack-protector -fno-exceptions -std=gnu++11 -O3 $(INCLUDE) $(MUSLFLAG) -D MINIMAL_LIBCXX
+CXXFLAGS := -m32 -Wall -nostdinc -nostdlib -fno-stack-protector -fno-exceptions -std=gnu++11 -O3 $(INCLUDE) $(MUSLFLAG) -D MINIMAL_LIBCXX

--- a/src/platform/linker/Makefile
+++ b/src/platform/linker/Makefile
@@ -2,7 +2,7 @@ include Makefile.src
 
 CC=gcc
 LD=ld
-CFLAGS=-D__x86__ -D_GNU_SOURCE -lpthread -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-format -ggdb3 -I$(SHAREDINC)
+CFLAGS=-m32 -D__x86__ -D_GNU_SOURCE -lpthread -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-format -ggdb3 -I$(SHAREDINC)
 LDFLAGS=-m elf_i386
 PRODUCTS=cos_linker gen_client_stub
 


### PR DESCRIPTION
This does not actually build all the way on x64 - but it gets a lot
further.

### Summary of this Pull Request (PR)

I attempted to get composite to build on my x64 Linux. I didn't get it completely - the linker app doesn't build on 64bit, and apparently I can't install a copy of 32 bit binutils along side 64 bit, so that's where I got stuck.

I ended up building a trusty chroot following these instructions: https://jblevins.org/log/ubuntu-chroot, which might be useful to link in your docs on building composite, as it worked out of the box.

Not sure if you are keen to merge these fixes, but I though I'll let the team decide rather than throw them away.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [X] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)

Well I have met @gparmer once at RTSS. 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

N/A it's just some build flags

- [ ] Comments adhere to the Style Guide (SG)
- [ ] Spacing adhere's to the SG
- [ ] Naming adhere's to the SG
- [ ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ ] I've made an attempt to remove all redundant code
- [ ] I've considered ways in which my changes might impact existing code, and cleaned it up
- [ ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ ] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- make
