### PR TITLE
Hwmap fix

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -15,6 +15,7 @@ The current primary contributors to _Composite_
 - **Robert Gifford and Lucas Baier** -- Undergraduate students at GWU working to provide rump kernel and TCap support
 - **Gregor Peach, Joseph Espy, Zach Day** -- Undergraduates working Satellite software (cFE)
 - **Vlad Nitu** -- PhD student at Toulouse University, France working on network function OS.
+- **Riley Kennedy** -- Undergraduate student at GWU working on DPDK port for network function OS.
 
 Significant past contributors
 -----------------------------

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -980,10 +980,8 @@ cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 		sz -= PAGE_SIZE;
 		pa += PAGE_SIZE;
 
-		if (sz > 0)
-			va = __page_bump_valloc(ci, PAGE_SIZE);
-		else
-			break;
+		if (sz <= 0) break;
+		va = __page_bump_valloc(ci, PAGE_SIZE);
 	}
 
 	return (void *)fva;

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -972,8 +972,9 @@ cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 	fva = __page_bump_valloc(ci, PAGE_SIZE);
 	va  = fva;
 	if (unlikely(!fva)) return NULL;
+	sz -= PAGE_SIZE;
 
-	do {
+	while (sz > 0) {
 		if (call_cap_op(hwc, CAPTBL_OP_HW_MAP, ci->pgtbl_cap, va, pa, 0)) BUG();
 
 		sz -= PAGE_SIZE;
@@ -981,8 +982,7 @@ cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 
 		va = __page_bump_valloc(ci, PAGE_SIZE);
 		if (unlikely(!va)) return NULL;
-
-	} while (sz > 0);
+	}
 
 	return (void *)fva;
 }

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -971,17 +971,19 @@ cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 
 	fva = __page_bump_valloc(ci, PAGE_SIZE);
 	va  = fva;
-	if (unlikely(!fva)) return NULL;
-	sz -= PAGE_SIZE;
 
-	while (sz > 0) {
+	while (1) {
+		if (unlikely(!va)) return NULL;
+
 		if (call_cap_op(hwc, CAPTBL_OP_HW_MAP, ci->pgtbl_cap, va, pa, 0)) BUG();
 
 		sz -= PAGE_SIZE;
 		pa += PAGE_SIZE;
 
-		va = __page_bump_valloc(ci, PAGE_SIZE);
-		if (unlikely(!va)) return NULL;
+		if (sz > 0)
+			va = __page_bump_valloc(ci, PAGE_SIZE);
+		else
+			break;
 	}
 
 	return (void *)fva;


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Restructures `cos_hw_map()` to allocate requested number of pages. Fixes an off-by-one error by subtracting a page from the size before entering the loop. Also, changes the do-while to a while loop so that a single page can be allocated if requested.

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)
**Currently running Ubuntu14 which doesn't support a new enough version of clang-format**

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):
- tested to see if `cos_hw_map()` incremented the bump allocator's next virt address correctly when called on a single page allocation and a multiple page allocation. 