### PR TITLE
Baremetal memory scan fix

### DIFF
--- a/src/kernel/include/shared/cos_config.h
+++ b/src/kernel/include/shared/cos_config.h
@@ -32,6 +32,11 @@
 
 #define COS_MEM_KERN_VA_SZ (1 << 24) /* 16 MB from KERN_START_VA + end of kernel image onward */
 
+#define COS_HW_MMIO_START_VA 0xf0000000 /* Assuming all hardware virtual addresses are beyond this */
+#define COS_PHYMEM_MAX_SZ (COS_HW_MMIO_START_VA-(COS_MEM_KERN_START_VA+COS_MEM_KERN_PA)) /* Maximum addressable physical memory */
+
+#define BOOT_KERN_MEMSCAN_MAX (COS_HW_MMIO_START_VA)
+
 /* To get more memory, we need many PTE caps in the captbl. So give
  * multiple pages to it. 5 is enough for 512 MBs.*/
 #define BOOT_CAPTBL_NPAGES 1

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -140,6 +140,9 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 #ifdef ENABLE_CONSOLE
 	console_init();
 #endif
+#ifdef ENABLE_VGA
+	vga_init();
+#endif
 	max = MAX((unsigned long)mboot->mods_addr,
 	          MAX((unsigned long)mboot->mmap_addr, (unsigned long)(chal_va2pa(&end))));
 	kern_paging_map_init((void *)(max + PGD_SIZE));
@@ -154,7 +157,7 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 	paging_init();
 #ifdef ENABLE_VGA
 	/* uses virtual address for VGA. should be after paging_init() */
-	vga_init();
+	vga_high_init();
 #endif
 	kern_boot_comp();
 	smp_init();

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -91,15 +91,20 @@ kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 		struct multiboot_mem_list *mem      = &mems[i];
 		u8_t *                     mod_end  = glb_memlayout.mod_end;
 		u8_t *                     mem_addr = chal_pa2va((paddr_t)mem->addr);
+		unsigned long              mem_len  = (mem->len > COS_PHYMEM_MAX_SZ ? COS_PHYMEM_MAX_SZ : mem->len); /* maximum allowed */ 
 
-		printk("\t- %d (%s): [%08llx, %08llx)\n", i, mem->type == 1 ? "Available" : "Reserved ", mem->addr,
-		       mem->addr + mem->len);
+		if (mem->addr > BOOT_KERN_MEMSCAN_MAX || mem->addr + mem_len > BOOT_KERN_MEMSCAN_MAX) {
+			printk("\tScanned maximum allowed regions\n");
+			break;
+		}
+		printk("\t- %d (%s): [%08llx, %08llx) sz = [%08lldKB, %ldKB)\n", i, mem->type == 1 ? "Available" : "Reserved ", mem->addr,
+		       mem->addr + mem->len, mem->len/1024, mem_len/1024);
 
 		/* is this the memory region we'll use for component memory? */
-		if (mem->type == 1 && mod_end >= mem_addr && mod_end < (mem_addr + mem->len)) {
-			unsigned long sz = (mem_addr + mem->len) - mod_end;
+		if (mem->type == 1 && mod_end >= mem_addr && mod_end < (mem_addr + mem_len)) {
+			unsigned long sz = (mem_addr + mem_len) - mod_end;
 
-			glb_memlayout.kmem_end = mem_addr + mem->len;
+			glb_memlayout.kmem_end = mem_addr + mem_len;
 			printk("\t  memory available at boot time: %lx (%ld MB + %ld KB)\n", sz, sz >> 20,
 			       (sz & ((1 << 20) - 1)) >> 10);
 		}

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -17,6 +17,7 @@ void console_init(void);
 #endif
 
 #ifdef ENABLE_VGA
+void vga_high_init(void);
 void vga_init(void);
 void vga_puts(const char *str);
 #endif

--- a/src/platform/i386/vga.c
+++ b/src/platform/i386/vga.c
@@ -161,15 +161,19 @@ cls(void)
 }
 
 /*
- * Clear the screen and initialize VIDEO, XPOS and YPOS.
  * VIDEO virtual address set to HIGH address.
  */
 void
+vga_high_init(void)
+{
+	video = chal_pa2va(VIDEO);
+}
+
+/* Clear the screen and initialize VIDEO, XPOS and YPOS. */
+void
 vga_init(void)
 {
-	int i = 0;
-
-	video = chal_pa2va(VIDEO);
+	video = (unsigned char *) VIDEO;
 
 	csr_x = 0;
 	csr_y = 0;


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Issue: If a region size is greater than the maximum possible in current composite, it breaks in the sense that it doesn't detect that region as usable.
   => `0xc0100000 + <region_size>` must be less than 1. what is addressable by composite (<1GB currently), 2. should also consider MMIO mappings (for ex. LAPIC is usually mapped at/after 0xFE000000). Fixed that!

VGA printks before paging init is also brought back as I'm not sure what the problem is or I'm not able to replicate it on the HW I've with me.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer @ryuxin 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- microbooter on Qemu, Optiplex 990 (i7 & i5)=4GB DIMM and Inspiron (i5 - newer PC) =8GB DIMM.
