### PR TITLE
Add component configuration with key-value pairs

### DIFF
--- a/src/components/implementation/no_interface/llbooter/boot_deps.h
+++ b/src/components/implementation/no_interface/llbooter/boot_deps.h
@@ -13,7 +13,7 @@
 #define THD_PRIO 5
 #define THD_PERIOD 10
 #define THD_BUDGET 5
-#define INIT_THDS_SIZE MAX_NUM_SPDS + 1
+#define INIT_THDS_SIZE MAX_NUM_COMPS + 1
 
 int num_cobj;
 
@@ -22,7 +22,12 @@ extern void *__inv_test_entry(int a, int b, int c);
 long boot_pgtbl_cap_transfer(int dst, int src, int cap_slot);
 long boot_thd_cap_transfer(int dst, int src, int cap_slot);
 
-struct cobj_header *hs[MAX_NUM_SPDS + 1];
+struct cobj_header *hs[MAX_NUM_COMPS + 1];
+
+typedef enum {
+	BOOT_COMP_FLAG_SCHED = 1,
+	BOOT_COMP_FLAG_MM    = 1<<1,
+} boot_comp_flag_t;
 
 /* The booter uses this to keep track of each comp */
 struct comp_cap_info {
@@ -33,18 +38,14 @@ struct comp_cap_info {
 	vaddr_t                 addr_start;
 	vaddr_t                 vaddr_mapped_in_booter;
 	vaddr_t                 upcall_entry;
-} new_comp_cap_info[MAX_NUM_SPDS + 1];
-
-typedef enum {
-	BOOT_COMP_FLAG_SCHED = 1,
-	BOOT_COMP_FLAG_MM    = 1<<1,
-} boot_comp_flag_t;
+	boot_comp_flag_t	special_type;
+} new_comp_cap_info[MAX_NUM_COMPS + 1];
 
 thdcap_t init_thds[INIT_THDS_SIZE];
 /* Keep track of the init_thds that have already been run once */
 size_t global_idx = 0;
 
-struct cos_defcompinfo new_defcompinfo[MAX_NUM_SPDS + 1];
+struct cos_defcompinfo new_defcompinfo[MAX_NUM_COMPS + 1];
 
 static vaddr_t
 boot_deps_map_sect(spdid_t spdid, vaddr_t dest_daddr)

--- a/src/components/implementation/no_interface/llbooter/comp_config.h
+++ b/src/components/implementation/no_interface/llbooter/comp_config.h
@@ -1,0 +1,66 @@
+#ifndef COMP_CONFIG_H
+#define COMP_CONFIG_H
+
+#include <cos_types.h>
+#include <consts.h>
+#include <string.h>
+
+struct cos_config_info_t *comp_configs[MAX_NUM_COMPS];
+
+enum
+{
+	SL_RUMPCOS = 0,
+	SHMEM,
+	SL_TEST_BOOT,
+};
+
+/*
+ * Define your component configuration here.
+ * The name of the cos_config_info struct should be that of the final object file
+ * for the component so other users can clearly associate components to their
+ * configurations.
+ *
+ * The first key-value pair should be the object name (same as the name you juse used),
+ * for the struct itself. The llbooter leverages this first key-value pair to match up
+ * object files to their appropriate components during runtime.
+ *
+ * After defining the remaining key-value pairs as you like, add your configuration struct
+ * to the master list which the llbooter will parse through.
+ * Add your own enum entry used to offset the config struct into the master list.
+ * This enum is only used within this header file.
+ *
+ * Use the below configuration for the Rump Kernel as an example.
+ */
+
+static struct cos_config_info_t sl_rumpcos;
+static struct cos_config_info_t shmem;
+static struct cos_config_info_t sl_test_boot;
+
+static void
+__init_configs()
+{
+	/* Rumpkernel configuration information */
+	strncpy(sl_rumpcos.kvp[COMP_KEY].key, "Component", KEY_LENGTH);
+	strncpy(sl_rumpcos.kvp[COMP_KEY].value, "sl_rumpcos", VALUE_LENGTH);
+	strncpy(sl_rumpcos.kvp[GREETING_KEY].key, "Greeting", KEY_LENGTH);
+	strncpy(sl_rumpcos.kvp[GREETING_KEY].value, "Config for a RK", VALUE_LENGTH);
+	comp_configs[SL_RUMPCOS] = &sl_rumpcos;
+
+	/* Shared memory configuration information */
+	strncpy(shmem.kvp[COMP_KEY].key, "Component", KEY_LENGTH);
+	strncpy(shmem.kvp[COMP_KEY].value, "shmem", VALUE_LENGTH);
+	strncpy(shmem.kvp[GREETING_KEY].key, "Greeting", KEY_LENGTH);
+	strncpy(shmem.kvp[GREETING_KEY].value, "Config for shared memory component",
+		VALUE_LENGTH);
+	comp_configs[SHMEM] = &shmem;
+
+	/* llboter_test configuration information */
+	strncpy(sl_test_boot.kvp[COMP_KEY].key, "Component", KEY_LENGTH);
+	strncpy(sl_test_boot.kvp[COMP_KEY].value, "sl_test_boot", VALUE_LENGTH);
+	strncpy(sl_test_boot.kvp[GREETING_KEY].key, "Greeting", KEY_LENGTH);
+	strncpy(sl_test_boot.kvp[GREETING_KEY].value, "Config for sl_test_boot",
+		VALUE_LENGTH);
+	comp_configs[SL_TEST_BOOT] = &sl_test_boot;
+}
+
+#endif /* COMP_CONFIG_H */

--- a/src/components/implementation/no_interface/llbooter/llbooter.c
+++ b/src/components/implementation/no_interface/llbooter/llbooter.c
@@ -1,6 +1,7 @@
 #include <cos_component.h>
 #include <cobj_format.h>
 #include "boot_deps.h"
+#include "comp_config.h"
 
 #define USER_CAPS_SYMB_NAME "ST_user_caps"
 
@@ -19,8 +20,6 @@ struct component_init_str {
 	int          startup;
 	char         init_str[INIT_STR_SZ];
 } __attribute__((packed));
-
-struct component_init_str *init_args;
 
 unsigned int *boot_sched;
 
@@ -140,32 +139,30 @@ boot_spd_symbs(struct cobj_header *h, spdid_t spdid, vaddr_t *comp_info, vaddr_t
 static int
 boot_process_cinfo(struct cobj_header *h, spdid_t spdid, vaddr_t heap_val, char *mem, vaddr_t symb_addr)
 {
-	int                               i;
+	int                                i;
+	char			  *comp_name;
+	char 			 *config_key;
+	char 		       *config_value;
 	struct cos_component_information *ci;
 
 	assert(symb_addr == round_to_page(symb_addr));
 	ci = (struct cos_component_information *)(mem);
+	ci->cos_this_spd_id = spdid;
+
+	for (i = 0 ; comp_configs[i] && i < MAX_NUM_COMPS ; i++) {
+		comp_name = comp_configs[i]->kvp[COMP_KEY].value;
+		if (strncmp(comp_name, h->name, VALUE_LENGTH)) continue;
+
+		config_key   = comp_configs[i]->kvp[GREETING_KEY].key;
+		config_value = comp_configs[i]->kvp[GREETING_KEY].value;
+		strncpy(ci->cos_config_info.kvp[GREETING_KEY].key, config_key, KEY_LENGTH);
+		strncpy(ci->cos_config_info.kvp[GREETING_KEY].value, config_value,
+			VALUE_LENGTH);
+	}
+
+
 
 	if (!ci->cos_heap_ptr) ci->cos_heap_ptr = heap_val;
-
-	ci->cos_this_spd_id = spdid;
-	ci->init_string[0]  = '\0';
-
-	for (i = 0; init_args[i].spdid; i++) {
-		char *start, *end;
-		int   len;
-
-		if (init_args[i].spdid != spdid) continue;
-
-		start = strchr(init_args[i].init_str, '\'');
-		if (!start) break;
-		start++;
-		end = strchr(start, '\'');
-		if (!end) break;
-		len = (int)(end - start);
-		memcpy(&ci->init_string[0], start, len);
-		ci->init_string[len] = '\0';
-	}
 
 	return 1;
 }
@@ -305,8 +302,7 @@ cos_init(void)
 	num_cobj = (int)cos_comp_info.cos_poly[1];
 	printc("num_cobj: %d\n", num_cobj);
 
-	init_args = (struct component_init_str *)cos_comp_info.cos_poly[3];
-	init_args++;
+	__init_configs();
 
 	printc("num cobjs: %d\n", num_cobj);
 	boot_find_cobjs(h, num_cobj);

--- a/src/components/implementation/tests/boot_test/test_booter.c
+++ b/src/components/implementation/tests/boot_test/test_booter.c
@@ -1,4 +1,5 @@
 #include <cos_kernel_api.h>
+#include <cos_component.h>
 #include <llprint.h>
 #include <llbooter_inv.h>
 
@@ -7,9 +8,16 @@
 void
 cos_init(void)
 {
+	struct cos_config_info_t *my_info;
+
 	prints("\n|*****************************|\n");
 	prints(" Wecome to test_boot component!\n");
 	prints("|*****************************|\n");
+
+	printc("Fetching boot configuration information\n");
+	my_info = cos_init_args();
+	printc("Greeting key: %s\n", my_info->kvp[GREETING_KEY].key);
+	printc("Greeting value: %s\n", my_info->kvp[GREETING_KEY].value);
 
 	cos_hypervisor_hypercall(BOOT_HYP_INIT_DONE, 0, 0, 0);
 }

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -181,10 +181,10 @@ cos_set_heap_ptr(void *addr)
 	cos_comp_info.cos_heap_ptr = (vaddr_t)addr;
 }
 
-static inline char *
+static inline struct cos_config_info_t *
 cos_init_args(void)
 {
-	return cos_comp_info.init_string;
+	return &cos_comp_info.cos_config_info;
 }
 
 #define COS_EXTERN_FN(fn) __cos_extern_##fn

--- a/src/kernel/include/shared/consts.h
+++ b/src/kernel/include/shared/consts.h
@@ -136,4 +136,8 @@ struct pt_regs {
 #define CPUID_OFFSET 1
 #define THDID_OFFSET 2
 
+#define KEY_VALUE_PAIRS 10
+#define KEY_LENGTH 25
+#define VALUE_LENGTH 100
+
 #endif

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -364,6 +364,26 @@ struct cos_stack_freelists {
 	struct stack_fl freelists[COMP_INFO_STACK_FREELISTS];
 };
 
+/*
+ * enum for defining the beginning set number of keys that all components will
+ * share in common.
+ */
+enum
+{
+	COMP_KEY = 0,
+	GREETING_KEY,
+	/* After this, the key values are free to use as components need them */
+};
+
+struct kv {
+	char key[KEY_LENGTH];
+	char value[VALUE_LENGTH];
+};
+
+struct cos_config_info_t {
+	struct kv kvp[KEY_VALUE_PAIRS];
+};
+
 /* move this to the stack manager assembly file, and use the ASM_... to access the relinquish variable */
 //#define ASM_OFFSET_TO_STK_RELINQ (sizeof(struct cos_stack_freelists) + sizeof(u32_t) * COMP_INFO_TMEM_STK_RELINQ)
 //#define ASM_OFFSET_TO_STK_RELINQ 8
@@ -374,6 +394,7 @@ struct cos_stack_freelists {
 
 struct cos_component_information {
 	struct cos_stack_freelists cos_stacks;
+	struct cos_config_info_t   cos_config_info;
 	long                       cos_this_spd_id;
 	u32_t                      cos_tmem_relinquish[COMP_INFO_TMEM];
 	u32_t                      cos_tmem_available[COMP_INFO_TMEM];
@@ -385,7 +406,6 @@ struct cos_component_information {
 	vaddr_t                            cos_user_caps;
 	struct restartable_atomic_sequence cos_ras[COS_NUM_ATOMIC_SECTIONS / 2];
 	vaddr_t                            cos_poly[COMP_INFO_POLY_NUM];
-	char                               init_string[COMP_INFO_INIT_STR_LEN];
 } __attribute__((aligned(PAGE_SIZE)));
 
 typedef enum {


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Enables configuration information to be passed into components based on the object file they come from.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [X] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer @phanikishoreg 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [X] Comments adhere to the Style Guide (SG)
- [X] Spacing adhere's to the SG
- [X] Naming adhere's to the SG
- [X] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [X] I've made an attempt to remove all redundant code
- [X] I've considered ways in which my changes might impact existing code, and cleaned it up
- [X] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [X] I've commented appropriately where code is tricky
- [X] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- llbooter_test.sh
