### PR TITLE
sl_thd WOKEN race

### DIFF
--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -114,6 +114,13 @@ sl_cs_owner(void)
 	return sl__globals()->lock.u.s.owner == sl_thd_thdcap(sl_thd_curr());
 }
 
+static inline int
+sl_is_runnable(struct sl_thd *t)
+{
+	/* WOKE threads are still runnable */
+	return (t->state == SL_THD_RUNNABLE || t->state == SL_THD_WOKEN);
+}
+
 /* ...not part of the public API */
 /*
  * @csi: current critical section value
@@ -462,8 +469,7 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 		}
 	}
 
-	//WOKE is subset of RUNNABLE so should be safe to dispatch to
-	assert(t->state == SL_THD_RUNNABLE || t->state == SL_THD_WOKEN);
+	assert(sl_is_runnable(t));
 	sl_cs_exit();
 
 	ret = sl_thd_activate(t, tok);

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -371,7 +371,7 @@ sl_thd_activate(struct sl_thd *t, sched_tok_t tok)
 		return cos_switch(sl_thd_thdcap(t), sl_thd_tcap(t), t->prio,
 				  g->timeout_next, g->sched_rcv, tok);
 	} else {
-		return cos_defswitch(sl_thd_thdcap(t), t->prio, t == g->sched_thd ? 
+		return cos_defswitch(sl_thd_thdcap(t), t->prio, t == g->sched_thd ?
 				     TCAP_TIME_NIL : g->timeout_next, tok);
 	}
 }
@@ -447,7 +447,7 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 
 		if (t->last_replenish == 0 || t->last_replenish + t->period <= now) {
 			tcap_res_t currbudget = 0;
-			cycles_t replenish    = now - ((now - t->last_replenish) % t->period);  
+			cycles_t replenish    = now - ((now - t->last_replenish) % t->period);
 
 			ret = 0;
 			currbudget = (tcap_res_t)cos_introspect(ci, sl_thd_tcap(t), TCAP_GET_BUDGET);
@@ -462,7 +462,8 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 		}
 	}
 
-	assert(t->state == SL_THD_RUNNABLE);
+	//WOKE is subset of RUNNABLE so should be safe to dispatch to
+	assert(t->state == SL_THD_RUNNABLE || t->state == SL_THD_WOKEN);
 	sl_cs_exit();
 
 	ret = sl_thd_activate(t, tok);
@@ -470,7 +471,7 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 	 * dispatch failed with -EPERM because tcap associated with thread t does not have budget.
 	 * Block the thread until it's next replenishment and return to the scheduler thread.
 	 *
-	 * If the thread is not replenished by the scheduler (replenished "only" by 
+	 * If the thread is not replenished by the scheduler (replenished "only" by
 	 * the inter-component delegations), block till next timeout and try again.
 	 */
 	if (unlikely(ret == -EPERM)) {
@@ -522,7 +523,7 @@ sl_cs_exit_switchto(struct sl_thd *to)
  * library-internal data-structures, and then the ability for the
  * scheduler thread to start its scheduling loop.
  *
- * sl_init(period); <- using `period` for scheduler periodic timeouts 
+ * sl_init(period); <- using `period` for scheduler periodic timeouts
  * sl_*;            <- use the sl_api here
  * ...
  * sl_sched_loop(); <- loop here. or using sl_sched_loop_nonblock();
@@ -538,11 +539,11 @@ void sl_sched_loop(void) __attribute__((noreturn));
  * with a RCV_NONBLOCK flag, the kernel returns to the calling thread immediately if
  * there are no pending events.
  *
- * This is useful for the system scheduler in a hierarchical settings where 
- * booter (perhaps only doing simple chronos delegations) hands off the 
+ * This is useful for the system scheduler in a hierarchical settings where
+ * booter (perhaps only doing simple chronos delegations) hands off the
  * system scheduling responsibility to another component.
  *
- * Note: sl_sched_loop_nonblock has same semantics as sl_sched_loop for 
+ * Note: sl_sched_loop_nonblock has same semantics as sl_sched_loop for
  * booter receive (INITRCV) end-point at the kernel level.
  */
 void sl_sched_loop_nonblock(void) __attribute__((noreturn));

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -17,7 +17,7 @@ typedef enum {
 	SL_THD_FREE = 0,
 	SL_THD_BLOCKED,
 	SL_THD_BLOCKED_TIMEOUT,
-	SL_THD_WOKEN, /* Unused because kernel may send redundant scheduling events! if a race causes a wakeup before the inevitable block */
+	SL_THD_WOKEN, /* Used for user level scheduling races where a thread is woken before it has a chance to block */
 	SL_THD_RUNNABLE,
 	SL_THD_DYING,
 } sl_thd_state_t;

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -157,7 +157,6 @@ update:
 void
 sl_thd_block(thdid_t tid)
 {
-
 	struct sl_thd *t;
 
 	/* TODO: dependencies not yet supported */
@@ -165,16 +164,13 @@ sl_thd_block(thdid_t tid)
 
 	sl_cs_enter();
 	t = sl_thd_curr();
-
 	if (unlikely(t->state == SL_THD_WOKEN)) {
 		t->state = SL_THD_RUNNABLE;
 	}
-
 	else if (sl_thd_block_no_cs(t, SL_THD_BLOCKED, 0)) {
 		sl_cs_exit();
 		return;
 	}
-
 	sl_cs_exit_schedule();
 
 	return;


### PR DESCRIPTION
### Summary of this Pull Request (PR)

**Add description here.**
Intended to solve a race that was occurring that would cause threads to deadlock in the case where a thread is woken before it actually calls block.

though this solves my issue i may have missed some necessary changes elsewhere in parts of the scheduler my code isn't using. 

updated state sl_thd state machine:
    - runnable -> blocked: when the thread blocks on an operation
    - runnable -> woke: when a thread is runnable and is `sl_wakeup`ed by another thread
    - woke -> runnable: when a thread blocks `sl_block`s when it has been previously `sl_wakeup`ed

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [ x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x ] Naming adhere's to the SG
- [x ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ x] I've made an attempt to remove all redundant code
- [x ] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ x] I've commented appropriately where code is tricky
- [ x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):
voter/demo_app.rs
-
