### PR TITLE
Grub memory scan consistency check

### DIFF
--- a/src/kernel/include/shared/cos_config.h
+++ b/src/kernel/include/shared/cos_config.h
@@ -33,7 +33,7 @@
 #define COS_HW_MMIO_MAX_SZ (1 << 27) /* Assuming a MAX of 128MB for MMIO. */
 #define COS_PHYMEM_MAX_SZ ((1 << 30) - (1 << 22) - COS_HW_MMIO_MAX_SZ) /* 1GB - 4MB - MMIO sz */
 
-#define COS_PHYMEM_END_PA COS_PHYMEM_MAX_SZ /* Maximum usable physical memory */
+#define COS_PHYMEM_END_PA ((1 << 30) - COS_HW_MMIO_MAX_SZ) /* Maximum usable physical memory */
 
 /* To get more memory, we need many PTE caps in the captbl. So give
  * multiple pages to it. 5 is enough for 512 MBs.*/

--- a/src/kernel/include/shared/cos_config.h
+++ b/src/kernel/include/shared/cos_config.h
@@ -30,12 +30,10 @@
 #define COS_MEM_COMP_START_VA ((1 << 30) + (1 << 22)) /* 1GB + 4MB (a relic) */
 #define COS_MEM_KERN_START_VA (0xc0000000) // COS_MEM_KERN_PA     /* currently, we don't do kernel relocation */
 
-#define COS_MEM_KERN_VA_SZ (1 << 24) /* 16 MB from KERN_START_VA + end of kernel image onward */
+#define COS_HW_MMIO_MAX_SZ (1 << 27) /* Assuming a MAX of 128MB for MMIO. */
+#define COS_PHYMEM_MAX_SZ ((1 << 30) - (1 << 22) - COS_HW_MMIO_MAX_SZ) /* 1GB - 4MB - MMIO sz */
 
-#define COS_HW_MMIO_START_VA 0xf0000000 /* Assuming all hardware virtual addresses are beyond this */
-#define COS_PHYMEM_MAX_SZ (COS_HW_MMIO_START_VA-(COS_MEM_KERN_START_VA+COS_MEM_KERN_PA)) /* Maximum addressable physical memory */
-
-#define BOOT_KERN_MEMSCAN_MAX (COS_HW_MMIO_START_VA)
+#define COS_PHYMEM_END_PA COS_PHYMEM_MAX_SZ /* Maximum usable physical memory */
 
 /* To get more memory, we need many PTE caps in the captbl. So give
  * multiple pages to it. 5 is enough for 512 MBs.*/

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -39,6 +39,9 @@ hextol(const char *s)
 
 extern u8_t end; /* from the linker script */
 
+#define MEM_KB_ONLY(x) (((x) & ((1 << 20) - 1)) >> 10)
+#define MEM_MB_ONLY(x) ((x) >> 20)
+
 void
 kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 {
@@ -91,22 +94,20 @@ kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 		struct multiboot_mem_list *mem      = &mems[i];
 		u8_t *                     mod_end  = glb_memlayout.mod_end;
 		u8_t *                     mem_addr = chal_pa2va((paddr_t)mem->addr);
-		unsigned long              mem_len  = (mem->len > COS_PHYMEM_MAX_SZ ? COS_PHYMEM_MAX_SZ : mem->len); /* maximum allowed */ 
+		unsigned long              mem_len  = (mem->len > COS_PHYMEM_MAX_SZ ? COS_PHYMEM_MAX_SZ : mem->len); /* maximum allowed */
 
-		if (mem->addr > BOOT_KERN_MEMSCAN_MAX || mem->addr + mem_len > BOOT_KERN_MEMSCAN_MAX) {
-			printk("\tScanned maximum allowed regions\n");
-			break;
-		}
-		printk("\t- %d (%s): [%08llx, %08llx) sz = [%08lldKB, %ldKB)\n", i, mem->type == 1 ? "Available" : "Reserved ", mem->addr,
-		       mem->addr + mem->len, mem->len/1024, mem_len/1024);
+		printk("\t- %d (%s): [%08llx, %08llx) sz = %ldMB + %ldKB\n", i, mem->type == 1 ? "Available" : "Reserved ", mem->addr,
+		       mem->addr + mem->len, MEM_MB_ONLY((u32_t)mem->len), MEM_KB_ONLY((u32_t)mem->len));
+
+		if (mem->addr > COS_PHYMEM_END_PA || mem->addr + mem_len > COS_PHYMEM_END_PA) continue;
 
 		/* is this the memory region we'll use for component memory? */
 		if (mem->type == 1 && mod_end >= mem_addr && mod_end < (mem_addr + mem_len)) {
 			unsigned long sz = (mem_addr + mem_len) - mod_end;
 
 			glb_memlayout.kmem_end = mem_addr + mem_len;
-			printk("\t  memory available at boot time: %lx (%ld MB + %ld KB)\n", sz, sz >> 20,
-			       (sz & ((1 << 20) - 1)) >> 10);
+			printk("\t  memory usable at boot time: %lx (%ld MB + %ld KB)\n", sz, MEM_MB_ONLY(sz),
+			       MEM_KB_ONLY(sz));
 		}
 	}
 	/* FIXME: check memory layout vs. the multiboot memory regions... */
@@ -124,7 +125,7 @@ kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 
 	wastage += mem_boot_start() - mem_bootc_end();
 
-	printk("\tAmount of wasted memory due to layout is %u MB + 0x%x B\n", wastage >> 20, wastage & ((1 << 20) - 1));
+	printk("\tAmount of wasted memory due to layout is %u MB + 0x%x B\n", MEM_MB_ONLY(wastage), wastage & ((1 << 20) - 1));
 
 	assert(STK_INFO_SZ == sizeof(struct cos_cpu_local_info));
 }


### PR DESCRIPTION
### Summary of this Pull Request (PR)

* Right now, we cannot use physical memory regions above 1GB so adding
  a consistency check to make sure that.
* Changed to allow scanning all regions but only use regions below 1GB.
* Assuming a MMIO size of 128MB (will need to be modified if we need more in any system.)

TESTED ON BAREMETAL and fixed a bug.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- Tested micro booter on Qemu, Optiplex 990 with 4GB module and Inspiron 3250 with 8GB module. 
