### PR TITLE
`cos_hw_map` logic simplified

### DIFF
--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -185,7 +185,7 @@ int cos_tcap_merge(tcap_t dst, tcap_t rm);
 hwcap_t cos_hw_alloc(struct cos_compinfo *ci, u32_t bitmap);
 int     cos_hw_attach(hwcap_t hwc, hwid_t hwid, arcvcap_t rcvcap);
 int     cos_hw_detach(hwcap_t hwc, hwid_t hwid);
-void *  cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len);
+void   *cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len);
 int     cos_hw_cycles_per_usec(hwcap_t hwc);
 int     cos_hw_cycles_thresh(hwcap_t hwc);
 

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -1005,27 +1005,18 @@ cos_hw_cycles_thresh(hwcap_t hwc)
 void *
 cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 {
-	size_t  sz;
-	vaddr_t fva, va;
+	size_t  sz, i;
+	vaddr_t va;
 
 	assert(ci && hwc && pa && len);
 
 	sz = round_up_to_page(len);
+	va = __page_bump_valloc(ci, sz);
+	if (unlikely(!va)) return NULL;
 
-	fva = __page_bump_valloc(ci, PAGE_SIZE);
-	va  = fva;
-
-	while (1) {
-		if (unlikely(!va)) return NULL;
-
-		if (call_cap_op(hwc, CAPTBL_OP_HW_MAP, ci->pgtbl_cap, va, pa, 0)) BUG();
-
-		sz -= PAGE_SIZE;
-		pa += PAGE_SIZE;
-
-		if (sz <= 0) break;
-		va = __page_bump_valloc(ci, PAGE_SIZE);
+	for (i = 0; i < sz; i += PAGE_SIZE) {
+		if (call_cap_op(hwc, CAPTBL_OP_HW_MAP, ci->pgtbl_cap, va + i, pa + i, 0)) BUG();
 	}
 
-	return (void *)fva;
+	return (void *)va;
 }


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Simplified the `cos_hw_map` logic to use valloc with sz parameter instead of looping to valloc as many pages in the code.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- microbooter on Qemu
- Tested this on RK env (udpserver test) both on Qemu and HW.