### PR TITLE
Enable tls management through capmgr component

### DIFF
--- a/src/components/implementation/capmgr/naive/init.c
+++ b/src/components/implementation/capmgr/naive/init.c
@@ -19,14 +19,15 @@ capmgr_comp_info_iter(void)
 	do {
 		spdid_t spdid = 0, sched_spdid = 0;
 		struct cap_comp_info *rci = NULL;
+		struct cos_compinfo tmp;
 		struct sl_thd *ithd = NULL;
 		u64_t chbits = 0, chschbits = 0;
 		pgtblcap_t pgtslot = 0;
 		captblcap_t captslot = 0;
 		compcap_t ccslot = 0;
-		vaddr_t vasfr = 0;
+		vaddr_t vasfr = 0, src_pg = 0;
 		capid_t capfr = 0;
-		int ret = 0, is_sched = 0;
+		int ret = 0, is_sched = 0, offset = 0;
 		int remain_child = 0;
 		spdid_t childid;
 		comp_flag_t ch_flags;
@@ -71,6 +72,26 @@ capmgr_comp_info_iter(void)
 			cap_info_initthd_init(rci, ithd, 0);
 		} else if (cos_spd_id() == spdid) {
 			cap_info_initthd_init(rci, sl__globals()->sched_thd, 0);
+		}
+
+		/*
+		 * Set tls region for this component
+		 * Expand the 2nd level pte within this component's page table at our new range
+		 */
+		tmp.pgtbl_cap = pgtslot;
+		tmp.memsrc    = ci;
+		ret = (int)cos_pgtbl_intern_alloc(&tmp, pgtslot, TLS_BASE_ADDR,
+					     PAGE_SIZE * TLS_NUM_PAGES);
+		assert(ret);
+
+		/* Place desired number of pages at this new range */
+		offset = 0;
+		for (i = 0 ; i < (signed)TLS_NUM_PAGES ; i++) {
+			src_pg = (vaddr_t)cos_page_bump_alloc(ci);
+			assert(src_pg);
+			ret = cos_mem_alias_at(&tmp, TLS_BASE_ADDR + offset, ci, src_pg);
+			assert(!ret);
+			offset += PAGE_SIZE;
 		}
 	} while (remaining > 0);
 

--- a/src/components/implementation/capmgr/naive/mem_mgr.c
+++ b/src/components/implementation/capmgr/naive/mem_mgr.c
@@ -65,3 +65,35 @@ memmgr_shared_page_map_cserialized(vaddr_t *pgaddr, int *unused, int idx)
 done:
 	return num_pages;
 }
+
+/* These functions return the address at which the gs register is set to */
+void *
+memmgr_tls_alloc(unsigned int dst_tid)
+{
+	/* Just return the vaddr range for this tid */
+	assert(dst_tid < MAX_NUM_THREADS);
+	return TLS_BASE_ADDR + (void *)(TLS_AREA_SIZE * dst_tid);
+}
+
+void *
+_memmgr_tls_alloc_and_set(void *area)
+{
+	spdid_t cur = cos_inv_token();
+	struct cap_comp_info  *cur_rci = cap_info_comp_find(cur);
+	struct cos_compinfo  *rci      = cap_info_ci(cur_rci);
+	struct cos_compinfo  *cur_ci   = cos_compinfo_get(cos_defcompinfo_curr_get());
+	void *addr;
+	unsigned int dst_thdcap;
+	int tid;
+
+	assert(cur_ci && rci);
+
+	dst_thdcap = sl_thd_curr()->aepinfo->thd;
+	tid        = cos_introspect(cur_ci, dst_thdcap, THD_GET_TID);
+	addr       = memmgr_tls_alloc(tid);
+	assert(addr);
+
+	cos_thd_mod(rci, dst_thdcap, addr);
+
+	return addr;
+}

--- a/src/components/interface/capmgr/memmgr.h
+++ b/src/components/interface/capmgr/memmgr.h
@@ -1,6 +1,7 @@
 #ifndef MEMMGR_H
 #define MEMMGR_H
 
+#include <cos_kernel_api.h>
 #include <cos_types.h>
 
 vaddr_t memmgr_heap_page_alloc(void);

--- a/src/components/interface/capmgr/memmgr.h
+++ b/src/components/interface/capmgr/memmgr.h
@@ -10,4 +10,23 @@ int memmgr_shared_page_alloc(vaddr_t *pgaddr);
 int memmgr_shared_page_allocn(int num_pages, vaddr_t *pgaddr);
 int memmgr_shared_page_map(int id, vaddr_t *pgaddr);
 
+/* This magic number is double the tls size defined in RK */
+#define TLS_AREA_SIZE 32
+#define TLS_NUM_PAGES (round_up_to_page(TLS_AREA_SIZE * MAX_NUM_THREADS) / PAGE_SIZE)
+#define TLS_BASE_ADDR 0x70000000
+
+void *memmgr_tls_alloc(unsigned int dst_tid);
+void *_memmgr_tls_alloc_and_set(void *area);
+
+static void *
+memmgr_tls_alloc_and_set(void *area)
+{
+	void *addr = _memmgr_tls_alloc_and_set(area);
+
+	/* Set area within addr for this tid */
+	*(void **)addr = area;
+
+	return addr;
+}
+
 #endif /* MEMMGR_H */

--- a/src/components/interface/capmgr/stubs/s_stub.S
+++ b/src/components/interface/capmgr/stubs/s_stub.S
@@ -12,6 +12,8 @@ cos_asm_server_stub_rets(capmgr_thd_retrieve_next_cserialized)
 cos_asm_server_stub(capmgr_asnd_create)
 cos_asm_server_stub(capmgr_asnd_key_create)
 
+cos_asm_server_stub(memmgr_tls_alloc)
+cos_asm_server_stub(_memmgr_tls_alloc_and_set)
 cos_asm_server_stub(memmgr_heap_page_allocn)
 cos_asm_server_stub_rets(memmgr_shared_page_allocn_cserialized)
 cos_asm_server_stub_rets(memmgr_shared_page_map_cserialized)

--- a/src/components/lib/posix/posix.c
+++ b/src/components/lib/posix/posix.c
@@ -250,38 +250,14 @@ cos_set_tid_address(int *tidptr)
 	return 0;
 }
 
-/* struct user_desc {
- *     int  		  entry_number; // Ignore
- *     unsigned int  base_addr; // Pass to cos thread mod
- *     unsigned int  limit; // Ignore
- *     unsigned int  seg_32bit:1;
- *     unsigned int  contents:2;
- *     unsigned int  read_exec_only:1;
- *     unsigned int  limit_in_pages:1;
- *     unsigned int  seg_not_present:1;
- *     unsigned int  useable:1;
- * };
+/*
+ * TLS is managed by capmgr component, if something needs tls, it should use capmgr
+ * Stub needed as libc_init expects there to be something to setup tls, although it doesn't
+ * do anything with tls immediately
  */
-
-void* backing_data[SL_MAX_NUM_THDS];
-
-static void
-setup_thread_area(struct sl_thd *thread, void* data)
-{
-	struct cos_compinfo *ci = cos_compinfo_get(cos_defcompinfo_curr_get());
-	thdid_t thdid = sl_thd_thdid(thread);
-
-	backing_data[thdid] = data;
-
-	cos_thd_mod(ci, sl_thd_thdcap(thread), &backing_data[thdid]);
-}
-
 int
-cos_set_thread_area(void* data)
-{
-	setup_thread_area(sl_thd_curr(), data);
-	return 0;
-}
+cos_set_thread_area_stub(void* data)
+{ return 0; }
 
 int
 cos_clone(int (*func)(void *), void *stack, int flags, void *arg, pid_t *ptid, void *tls, pid_t *ctid)
@@ -293,7 +269,9 @@ cos_clone(int (*func)(void *), void *stack, int flags, void *arg, pid_t *ptid, v
 
 	struct sl_thd * thd = sl_thd_alloc((cos_thd_fn_t) func, arg);
 	if (tls) {
-		setup_thread_area(thd, tls);
+		/* Make sure TLS is managed by */
+		printc("ERROR: %s needs tls, handle this with capmgr component\n", __func__);
+		assert(0);
 	}
 	return sl_thd_thdid(thd);
 }
@@ -492,7 +470,7 @@ syscall_emulation_setup(void)
 
 	libc_syscall_override((cos_syscall_t)cos_gettid, __NR_gettid);
 	libc_syscall_override((cos_syscall_t)cos_tkill, __NR_tkill);
-	libc_syscall_override((cos_syscall_t)cos_set_thread_area, __NR_set_thread_area);
+	libc_syscall_override((cos_syscall_t)cos_set_thread_area_stub, __NR_set_thread_area);
 	libc_syscall_override((cos_syscall_t)cos_set_tid_address, __NR_set_tid_address);
 	libc_syscall_override((cos_syscall_t)cos_clone, __NR_clone);
 	libc_syscall_override((cos_syscall_t)cos_futex, __NR_futex);


### PR DESCRIPTION
### Summary of this Pull Request (PR)

This PR adds tls management to the capmgr component. Upon boot, the capmgr component maps a tls region for every possible thread in the system. Each thread, (identified with thread id), has a virtual address offset from 0x7000... where there will be guaranteed mapped pages. Each component has different mapped pages into this region. There are two interfaces which other components can manage their tls regions. The first simply returns the virtual address at which the component has its TLS range. This lets components like the rumpkernel who already manage their own tls continue to do this with minimal changes. Capmgr component tls management for the RK is debugged and will be coming in a later PR. The second interface included in this PR is for components to set the current running thread tls region. This enables components that need Rust and other tls related necessities to easily set up their tls region when needed. **This second interface has not yet been debugged for use with Rust.** I will be working with @maloneya to debug when he begins using this for his Rust components.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [X] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer, @Others, @phanikishoreg 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [X] Comments adhere to the Style Guide (SG)
- [X] Spacing adhere's to the SG
- [X] Naming adhere's to the SG
- [X] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [X] I've made an attempt to remove all redundant code
- [X] I've considered ways in which my changes might impact existing code, and cleaned it up
- [X] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [X] I've commented appropriately where code is tricky
- [X] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- rumpkern_boot.sh
- llbooter_pong.sh
- llbooter_test.sh
- micro_boot.sh
- unit_capmgrtest.sh
- unit_hierschedcomps.sh
- unit_schedcomp.sh
- unit_schedtests.sh
