### PR TITLE
Fixed broken cxx test (broken from sl integration in libposix)

### DIFF
--- a/src/components/implementation/tests/unit_cxx/cxx.cc
+++ b/src/components/implementation/tests/unit_cxx/cxx.cc
@@ -94,7 +94,7 @@ rtti_test()
 	Person *a1, *a2;       /*pointers to base class */
 	a1 = new Employee();   /*Pointer to Employee object*/
 	a2 = new Person();     /*Pointer to Person object*/
-	
+
 	cout << "rtti test >>> dynamic_cast" << endl;
 	my_function(a1);
 	delete a1;
@@ -146,17 +146,9 @@ string_test()
 Global_foo foo;
 Global_bar bar;
 
-extern "C" void 
+extern "C" void
 cos_init(void *args)
 {
-	struct cos_defcompinfo *defci;
-	struct cos_compinfo *cinfo;
-
-	defci = cos_defcompinfo_curr_get();
-	cinfo = cos_compinfo_get(defci);
-	cos_meminfo_init(&cinfo->mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
-	cos_defcompinfo_init();
-
 	cout << "=========CXX TEST=========" << endl;
 	basic_test();
 	template_test();
@@ -168,4 +160,6 @@ cos_init(void *args)
 	vector_test();
 	string_test();
 	cout << "==========CXX TEST DONE=========" << endl;
+
+	SPIN();
 }


### PR DESCRIPTION
### Summary of this Pull Request (PR)

* defcompinfo is initialized in the posix lib including meminfo_init and sl_init.
  The unit cxx re inits meminfo, which was earlier used by sl_init to create an `idle` thread
  up on `sl_init`. So, mmap in posix was bombing out! Fixed it!

* We need a checklist for what should be tested for a PR.
  More so, Gabe has been stressing this point a lot, we need a cleaner UNIT TEST SUITE.
  Just printing SUCCESS/FAILURE in many so when someone runs the scripts from the
  checklist, they know what's FAILING/PASSING and make notes in their PR to begin with!

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 
@ryuxin @vnitu02 fyi!

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- unit_cxx.sh - only modified unit_cxx/cxx.cc, nothing else in the system should be affected with this change!
