### PR TITLE
Bugfix in AEP alloc with sl_capmgr!

### DIFF
--- a/src/components/lib/sl/sl_capmgr.c
+++ b/src/components/lib/sl/sl_capmgr.c
@@ -171,13 +171,11 @@ done:
 }
 
 static struct sl_thd *
-sl_thd_aep_alloc_no_cs(cos_aepthd_fn_t fn, void *data, struct cos_defcompinfo *comp, sl_thd_property_t prps, cos_aepkey_t key)
+sl_thd_aep_alloc_no_cs(cos_aepthd_fn_t fn, void *data, sl_thd_property_t prps, cos_aepkey_t key)
 {
 	struct sl_thd       *t     = NULL;
 	struct cos_aep_info *aep   = NULL;
 	int                  owntc = 0;
-
-	if (comp == NULL || comp->id == 0) goto done;
 
 	aep = sl_thd_alloc_aep_backend();
 	if (!aep) goto done;
@@ -211,7 +209,7 @@ sl_thd_aep_alloc(cos_aepthd_fn_t fn, void *data, int own_tcap, cos_aepkey_t key)
 	struct sl_thd *t = NULL;
 
 	sl_cs_enter();
-	t = sl_thd_aep_alloc_no_cs(fn, data, NULL, own_tcap ? SL_THD_PROPERTY_OWN_TCAP : 0, key);
+	t = sl_thd_aep_alloc_no_cs(fn, data, own_tcap ? SL_THD_PROPERTY_OWN_TCAP : 0, key);
 	sl_cs_exit();
 
 	return t;

--- a/src/components/lib/sl/sl_raw.c
+++ b/src/components/lib/sl/sl_raw.c
@@ -128,7 +128,7 @@ done:
 }
 
 static struct sl_thd *
-sl_thd_aep_alloc_no_cs(cos_aepthd_fn_t fn, void *data, struct cos_defcompinfo *comp, sl_thd_property_t prps, cos_aepkey_t key)
+sl_thd_aep_alloc_no_cs(cos_aepthd_fn_t fn, void *data, sl_thd_property_t prps, cos_aepkey_t key)
 {
 	struct cos_defcompinfo *dci = cos_defcompinfo_curr_get();
 	struct sl_thd          *t   = NULL;
@@ -210,7 +210,7 @@ sl_thd_aep_alloc(cos_aepthd_fn_t fn, void *data, int own_tcap, cos_aepkey_t key)
 	struct sl_thd *t = NULL;
 
 	sl_cs_enter();
-	t = sl_thd_aep_alloc_no_cs(fn, data, NULL, own_tcap ? SL_THD_PROPERTY_OWN_TCAP : 0, 0);
+	t = sl_thd_aep_alloc_no_cs(fn, data, own_tcap ? SL_THD_PROPERTY_OWN_TCAP : 0, 0);
 	sl_cs_exit();
 
 	return t;


### PR DESCRIPTION
### Summary of this Pull Request (PR)

* Allocating AEP in the current component doesn't need defcompinfo
  struct and is passed NULL. In the intern api, check for defcompinfo
  pointer (added through a copy mistake) makes it unusable.
  Robbie debugged this in RK env, thanks to him! 

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer @RobertGiff 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- micro_booter, unit_capmgr, unit_schedcomp, unit_hiersched - none use this API.
- Tested the fix in RK env also where the API is used
