### PR TITLE
Implementation of user-level fault handler

### DIFF
--- a/src/components/implementation/no_interface/llbooter/boot_deps.h
+++ b/src/components/implementation/no_interface/llbooter/boot_deps.h
@@ -14,13 +14,13 @@
 extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t arg3, word_t *ret2, word_t *ret3);
 
 /*Assembly function for sinv for the fault handlers */
-extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
-extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
 
 extern int num_cobj;
 extern int capmgr_spdid;
@@ -124,7 +124,7 @@ boot_spd_initaep_get(spdid_t spdid)
 
 /* The fault handlers*/
 void
-fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in div by zero error fault handler, fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -132,15 +132,16 @@ fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr,
 }
 
 void
-fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in memory access handler, memory access fault happens in component:%u\n\n", cos_inv_token());
+	//boot_thd_done(cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
 	return;
 }
 
 void
-fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in breapoint trap handler, breapoint trap happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -148,7 +149,7 @@ fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr,
 }
 
 void
-fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild instruction trap handler, invaild instruction happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -156,7 +157,7 @@ fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_a
 }
 
 void
-fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in bound range exceed fault handler, bound range exceed fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -164,7 +165,7 @@ fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr, un
 }
 
 void
-fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in component not exists fault handler, component not exists fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -172,7 +173,7 @@ fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr, 
 }
 
 void
-fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
+fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild component fault handler, invaild component fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -213,6 +214,8 @@ static void
 boot_fault_handler_sinv_alloc(spdid_t spdid)
 {
 	invtoken_t  token = (invtoken_t)spdid;
+
+	printc("spdid: %d\n", spdid);
 
 	struct cos_compinfo *comp_info = boot_spd_compinfo_get(spdid);
 	struct cos_compinfo *boot_info = boot_spd_compinfo_curr_get();

--- a/src/components/implementation/no_interface/llbooter/boot_deps.h
+++ b/src/components/implementation/no_interface/llbooter/boot_deps.h
@@ -14,13 +14,13 @@
 extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t arg3, word_t *ret2, word_t *ret3);
 
 /*Assembly function for sinv for the fault handlers */
-extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
 
 extern int num_cobj;
 extern int capmgr_spdid;
@@ -124,7 +124,7 @@ boot_spd_initaep_get(spdid_t spdid)
 
 /* The fault handlers*/
 void
-fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in div by zero error fault handler, fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -132,16 +132,15 @@ fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in memory access handler, memory access fault happens in component:%u\n\n", cos_inv_token());
-	//boot_thd_done(cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
 	return;
 }
 
 void
-fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in breapoint trap handler, breapoint trap happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -149,7 +148,7 @@ fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild instruction trap handler, invaild instruction happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -157,7 +156,7 @@ fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_a
 }
 
 void
-fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in bound range exceed fault handler, bound range exceed fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -165,7 +164,7 @@ fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in component not exists fault handler, component not exists fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -173,7 +172,7 @@ fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild component fault handler, invaild component fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -214,8 +213,6 @@ static void
 boot_fault_handler_sinv_alloc(spdid_t spdid)
 {
 	invtoken_t  token = (invtoken_t)spdid;
-
-	printc("spdid: %d\n", spdid);
 
 	struct cos_compinfo *comp_info = boot_spd_compinfo_get(spdid);
 	struct cos_compinfo *boot_info = boot_spd_compinfo_curr_get();

--- a/src/components/implementation/no_interface/llbooter/boot_deps.h
+++ b/src/components/implementation/no_interface/llbooter/boot_deps.h
@@ -11,16 +11,16 @@
 #include <bitmap.h>
 
 /* Assembly function for sinv from new component */
-extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t *ret2, word_t *ret3);
+extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t arg3, word_t *ret2, word_t *ret3);
 
 /*Assembly function for sinv for the fault handlers */
-extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
-extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr);
+extern word_t fh_div_by_zero_err_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_memory_access_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_breakpoint_trap_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_invalid_instruction_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_bound_exceed_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_comp_not_exsit_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
+extern word_t fh_sinv_invalid_comp_inv(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type);
 
 extern int num_cobj;
 extern int capmgr_spdid;
@@ -124,7 +124,7 @@ boot_spd_initaep_get(spdid_t spdid)
 
 /* The fault handlers*/
 void
-fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in div by zero error fault handler, fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -132,7 +132,7 @@ fh_div_by_zero_err(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in memory access handler, memory access fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -140,7 +140,7 @@ fh_memory_access(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in breapoint trap handler, breapoint trap happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -148,7 +148,7 @@ fh_breakpoint_trap(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild instruction trap handler, invaild instruction happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -156,7 +156,7 @@ fh_invalid_instruction(unsigned long sp, unsigned long ip, unsigned long fault_a
 }
 
 void
-fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in bound range exceed fault handler, bound range exceed fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -164,7 +164,7 @@ fh_bound_exceed(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in component not exists fault handler, component not exists fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -172,7 +172,7 @@ fh_comp_not_exsit(unsigned long sp, unsigned long ip, unsigned long fault_addr)
 }
 
 void
-fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr)
+fh_sinv_invalid_comp(unsigned long sp, unsigned long ip, unsigned long fault_addr, unsigned long fault_type)
 {
 	PRINTLOG(PRINT_DEBUG, "in invaild component fault handler, invaild component fault happens in component:%u\n\n", cos_inv_token());
 	call_cap_op(0, 0, 0, 0, 0, 0);
@@ -683,7 +683,7 @@ __hypercall_resource_access_check(spdid_t dstid, spdid_t srcid, int capmgr_ignor
 }
 
 word_t
-hypercall_entry(word_t *ret2, word_t *ret3, int op, word_t arg3, word_t arg4)
+hypercall_entry(word_t *ret2, word_t *ret3, int op, word_t arg3, word_t arg4, word_t arg5)
 {
 	int ret1 = 0;
 	spdid_t client = cos_inv_token();

--- a/src/components/implementation/no_interface/llbooter/llbooter.c
+++ b/src/components/implementation/no_interface/llbooter/llbooter.c
@@ -354,6 +354,7 @@ boot_create_cap_system(void)
 		if (boot_comp_map(h, spdid, ci)) BUG();
 
 		boot_newcomp_create(spdid, boot_spd_compinfo_get(spdid));
+		boot_fault_handler_sinv_alloc(spdid);
 		PRINTLOG(PRINT_DEBUG, "Comp %d (%s) created @ %x!\n", h->id, h->name, sect->vaddr);
 	}
 

--- a/src/components/implementation/no_interface/llbooter/s_stub.S
+++ b/src/components/implementation/no_interface/llbooter/s_stub.S
@@ -1,4 +1,13 @@
 #include <cos_asm_server_stub_simple_stack.h>
 
 .text
+
+cos_asm_server_stub(fh_div_by_zero_err)
+cos_asm_server_stub(fh_memory_access)
+cos_asm_server_stub(fh_breakpoint_trap)
+cos_asm_server_stub(fh_invalid_instruction)
+cos_asm_server_stub(fh_bound_exceed)
+cos_asm_server_stub(fh_comp_not_exsit)
+cos_asm_server_stub(fh_sinv_invalid_comp)
+
 cos_asm_server_stub_rets(hypercall_entry)

--- a/src/components/implementation/pong/pingpong/pong.c
+++ b/src/components/implementation/pong/pingpong/pong.c
@@ -42,9 +42,9 @@ call_arg(int p1)
 }
 
 void
-call_args(int p1, int p2, int p3)
+call_args(int p1, int p2, int p3, int p4)
 {
-	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%u. args: p1:%d p2:%d p3:%d\n", cos_inv_token(), p1, p2, p3);
+	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%u. args: p1:%d p2:%d p3:%d p4:%d\n", cos_inv_token(), p1, p2, p3, p4);
 	return;
 }
 

--- a/src/components/implementation/tests/unit_pingpong/ping.c
+++ b/src/components/implementation/tests/unit_pingpong/ping.c
@@ -7,7 +7,7 @@
 void cos_init(void)
 {
 	int r1 = 0, r2 = 0;
-	int a = 1, b = 2, c = 3;
+	int a = 1, b = 2, c = 3, d = 4;
 
 	PRINTLOG(PRINT_DEBUG, "Welcome to the ping component\n");
 
@@ -19,7 +19,7 @@ void cos_init(void)
 
 	PRINTLOG(PRINT_DEBUG, "Invoking pong interface w/ arguments:\n");
 	call_arg(a);
-	call_args(a, b, c);
+	call_args(a, b, c, d);
 
 	PRINTLOG(PRINT_DEBUG, "Invoking pong interface w/ multiple-rets:\n");
 	call_3rets(&r1, &r2, a, b, c);

--- a/src/components/include/cos_asm_server_stub_simple_stack.h
+++ b/src/components/include/cos_asm_server_stub_simple_stack.h
@@ -32,8 +32,9 @@ name##_inv:                        \
 	xor %ebp, %ebp;            \
 	pushl %edi;                \
 	pushl %esi;                \
+	pushl %ebx;                \
 	call name ;                \
-	addl $16, %esp;            \
+	addl $20, %esp;            \
 	                           \
 	movl %eax, %ecx;           \
 	movl $RET_CAP, %eax;       \
@@ -53,13 +54,14 @@ name##_rets_inv:                       \
 	xor %ebp, %ebp;		       \
 	pushl %edi;                    \
 	pushl %esi;                    \
+	pushl %ebx;                    \
 	movl %esp, %ecx;               \
-	addl $20, %ecx;                \
+	addl $24, %ecx;                \
 	pushl %ecx;                    \
 	subl $4, %ecx;                 \
 	pushl %ecx;                    \
 	call name ;                    \
-	addl $24, %esp;                \
+	addl $28, %esp;                \
 	popl %esi;                     \
 	popl %edi;                     \
 	                               \

--- a/src/components/include/hypercall.h
+++ b/src/components/include/hypercall.h
@@ -27,7 +27,7 @@ hypercall_comp_child_next(spdid_t c, spdid_t *child, comp_flag_t *flags)
 	word_t r2 = 0, r3 = 0;
 	int ret;
 
-	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CHILD_NEXT, c, 0, &r2, &r3);
+	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CHILD_NEXT, c, 0, 0, &r2, &r3);
 	if (ret < 0) return ret;
 	*child = (spdid_t)r2;
 	*flags = (comp_flag_t)r3;
@@ -42,7 +42,7 @@ hypercall_comp_init_done(void)
 	 * to be used only by the booter child threads
 	 * higher-level components use, schedinit interface to SINV to parent for init
 	 */
-	return cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INIT_DONE, 0, 0);
+	return cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INIT_DONE, 0, 0, 0);
 }
 
 /* Note: This API can be called ONLY by components that manage capability resources */
@@ -67,8 +67,8 @@ hypercall_comp_initaep_get(spdid_t spdid, int is_sched, struct cos_aep_info *aep
 	}
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret = cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INITAEP_GET,
-			spdid << 16 | thdslot, rcvslot << 16 | tcslot);
+	ret = cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INITAEP_GET,
+			spdid << 16 | thdslot, rcvslot << 16 | tcslot, 0);
 	if (ret) return ret;
 
 	aep->thd = thdslot;
@@ -95,8 +95,8 @@ hypercall_comp_info_get(spdid_t spdid, pgtblcap_t *ptslot, captblcap_t *ctslot, 
 	assert(*compslot);
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INFO_GET,
-			     spdid << 16 | (*compslot), (*ptslot) << 16 | (*ctslot), &r2, &r3);
+	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INFO_GET,
+			     spdid << 16 | (*compslot), (*ptslot) << 16 | (*ctslot), 0, &r2, &r3);
 	*parentid = r2;
 
 	return ret;
@@ -118,8 +118,8 @@ hypercall_comp_info_next(pgtblcap_t *ptslot, captblcap_t *ctslot, compcap_t *com
 	assert(*compslot);
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret =  cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INFO_NEXT,
-			      (*compslot), (*ptslot) << 16 | (*ctslot), &r2, &r3);
+	ret =  cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INFO_NEXT,
+			      (*compslot), (*ptslot) << 16 | (*ctslot), 0, &r2, &r3);
 	*compid        = r2;
 	*comp_parentid = r3;
 
@@ -130,7 +130,7 @@ hypercall_comp_info_next(pgtblcap_t *ptslot, captblcap_t *ctslot, compcap_t *com
 static inline int
 hypercall_comp_frontier_get(spdid_t spdid, vaddr_t *vasfr, capid_t *capfr)
 {
-	return cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_FRONTIER_GET, spdid, 0, vasfr, capfr);
+	return cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_FRONTIER_GET, spdid, 0, 0, vasfr, capfr);
 }
 
 /* Note: This API can be called ONLY by components that manage capability resources */
@@ -142,7 +142,7 @@ hypercall_comp_compcap_get(spdid_t spdid)
 
 	assert(compslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_COMPCAP_GET, spdid, compslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_COMPCAP_GET, spdid, compslot, 0)) return 0;
 
 	return compslot;
 }
@@ -156,7 +156,7 @@ hypercall_comp_captblcap_get(spdid_t spdid)
 
 	assert(ctslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CAPTBLCAP_GET, spdid, ctslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CAPTBLCAP_GET, spdid, ctslot, 0)) return 0;
 
 	return ctslot;
 }
@@ -170,7 +170,7 @@ hypercall_comp_pgtblcap_get(spdid_t spdid)
 
 	assert(ptslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_PGTBLCAP_GET, spdid, ptslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_PGTBLCAP_GET, spdid, ptslot, 0)) return 0;
 
 	return ptslot;
 }
@@ -181,7 +181,7 @@ hypercall_comp_capfrontier_get(spdid_t spdid)
 	word_t unused;
 	capid_t cap_frontier;
 
-	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CAPFRONTIER_GET, spdid, 0, &cap_frontier, &unused)) return 0;
+	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CAPFRONTIER_GET, spdid, 0, 0, &cap_frontier, &unused)) return 0;
 
 	return cap_frontier;
 }
@@ -189,7 +189,7 @@ hypercall_comp_capfrontier_get(spdid_t spdid)
 static inline int
 hypercall_numcomps_get(void)
 {
-	return cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_NUMCOMPS_GET, 0, 0);
+	return cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_NUMCOMPS_GET, 0, 0, 0);
 }
 
 #endif /* HYPERCALL_H */

--- a/src/components/interface/pong/pong.h
+++ b/src/components/interface/pong/pong.h
@@ -7,7 +7,7 @@ void call_three(void);
 void call_four(void);
 
 void call_arg(int p1);
-void call_args(int p1, int p2, int p3);
+void call_args(int p1, int p2, int p3, int p4);
 
 void call_3rets(int *r2, int *r3, int p1, int p2, int p3);
 

--- a/src/components/lib/c_stub.c
+++ b/src/components/lib/c_stub.c
@@ -33,11 +33,11 @@ SS_ipc_client_fault(cos_flt_off flt)
 __attribute__((regparm(1))) int
 SS_ipc_client_marshal_args(struct usr_inv_cap *uc, long p0, long p1, long p2, long p3)
 {
-	return cos_sinv(uc->cap_no, 0, p0, p1, p2);
+	return cos_sinv(uc->cap_no, p0, p1, p2, p3);
 }
 
 __attribute__((regparm(1))) int
 SS_ipc_client_marshal_args_rets(struct usr_inv_cap *uc, long *r2, long *r3, long p0, long p1, long p2, long p3)
 {
-	return cos_sinv_rets(uc->cap_no, 0, p0, p1, p2, (word_t *)r2, (word_t *)r3);
+	return cos_sinv_rets(uc->cap_no, p0, p1, p2, p3, (word_t *)r2, (word_t *)r3);
 }

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -969,8 +969,7 @@ composite_syscall_handler(struct pt_regs *regs)
 	/* fast path: invocation return (avoiding captbl accesses) */
 	if (cap == COS_DEFAULT_RET_CAP) {
 		/* No need to lookup captbl */
-		sret_ret(thd, regs, cos_info);
-		return 0;
+		return sret_ret(thd, regs, cos_info);
 	}
 
 	/* FIXME: use a cap for print */
@@ -994,7 +993,7 @@ composite_syscall_handler(struct pt_regs *regs)
 	}
 	/* fastpath: invocation */
 	if (likely(ch->type == CAP_SINV)) {
-		sinv_call(thd, (struct cap_sinv *)ch, regs, cos_info);
+		sinv_call(thd, (struct cap_sinv *)ch, regs, cos_info, 0);
 		return 0;
 	}
 
@@ -1489,8 +1488,7 @@ static int __attribute__((noinline)) composite_syscall_slowpath(struct pt_regs *
 		 * We usually don't have sret cap as we have 0 as the
 		 * default return cap.
 		 */
-		sret_ret(thd, regs, cos_info);
-		return 0;
+		return sret_ret(thd, regs, cos_info);
 	}
 	case CAP_TCAP: {
 		/* TODO: Validate that all tcaps are on the same core */

--- a/src/kernel/include/inv.h
+++ b/src/kernel/include/inv.h
@@ -322,9 +322,10 @@ sret_ret(struct thread *thd, struct pt_regs *regs, struct cos_cpu_local_info *co
 		__userregs_set(regs, -EFAULT, __userregs_getsp(regs), __userregs_getip(regs));
 		goto ret;
 	}
+
 	pgtbl_update(ci->pgtbl);
 	/* Set return sp and ip and function return value in eax */
-	__userregs_set(regs, -1, sp, ip);
+	__userregs_set(regs, __userregs_getinvret(regs), sp, ip);
 	ret:
 	if (unlikely(fault_flag)) {
 		copy_all_regs(&(thd->fault_regs), regs);

--- a/src/kernel/include/inv.h
+++ b/src/kernel/include/inv.h
@@ -322,7 +322,6 @@ sret_ret(struct thread *thd, struct pt_regs *regs, struct cos_cpu_local_info *co
 		__userregs_set(regs, -EFAULT, __userregs_getsp(regs), __userregs_getip(regs));
 		goto ret;
 	}
-
 	pgtbl_update(ci->pgtbl);
 	/* Set return sp and ip and function return value in eax */
 	__userregs_set(regs, __userregs_getinvret(regs), sp, ip);

--- a/src/kernel/include/inv.h
+++ b/src/kernel/include/inv.h
@@ -268,7 +268,7 @@ arcv_deactivate(struct cap_captbl *t, capid_t capin, livenessid_t lid)
  */
 
 static inline void
-sinv_call(struct thread *thd, struct cap_sinv *sinvc, struct pt_regs *regs, struct cos_cpu_local_info *cos_info)
+sinv_call(struct thread *thd, struct cap_sinv *sinvc, struct pt_regs *regs, struct cos_cpu_local_info *cos_info, unsigned long fault_flag)
 {
 	unsigned long ip, sp;
 
@@ -288,7 +288,7 @@ sinv_call(struct thread *thd, struct cap_sinv *sinvc, struct pt_regs *regs, stru
 		return;
 	}
 
-	if (unlikely(thd_invstk_push(thd, &sinvc->comp_info, ip, sp, cos_info))) {
+	if (unlikely(thd_invstk_push(thd, &sinvc->comp_info, ip, sp, fault_flag, cos_info))) {
 		__userregs_set(regs, -1, sp, ip);
 		return;
 	}
@@ -303,28 +303,34 @@ sinv_call(struct thread *thd, struct cap_sinv *sinvc, struct pt_regs *regs, stru
 	return;
 }
 
-static inline void
+static inline int
 sret_ret(struct thread *thd, struct pt_regs *regs, struct cos_cpu_local_info *cos_info)
 {
 	struct comp_info *ci;
 	unsigned long     ip, sp;
+	unsigned long     fault_flag = 1;
 
-	ci = thd_invstk_pop(thd, &ip, &sp, cos_info);
+	ci = thd_invstk_pop(thd, &ip, &sp, &fault_flag, cos_info);
 	if (unlikely(!ci)) {
 		__userregs_set(regs, 0xDEADDEAD, 0, 0);
-		return;
+		goto ret;
 	}
 
 	if (unlikely(!ltbl_isalive(&ci->liveness))) {
 		printk("cos: ret comp (liveness %d) doesn't exist!\n", ci->liveness.id);
 		// FIXME: add fault handling here.
 		__userregs_set(regs, -EFAULT, __userregs_getsp(regs), __userregs_getip(regs));
-		return;
+		goto ret;
 	}
-
 	pgtbl_update(ci->pgtbl);
 	/* Set return sp and ip and function return value in eax */
-	__userregs_set(regs, __userregs_getinvret(regs), sp, ip);
+	__userregs_set(regs, -1, sp, ip);
+	ret:
+	if (unlikely(fault_flag)) {
+		copy_all_regs(&(thd->fault_regs), regs);
+		return 1;
+	}
+	return 0;
 }
 
 static void

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -223,40 +223,54 @@ captbl_idsize(cap_t c)
  * LLBooter initial captbl setup:
  * 0 = sret,
  * 1-3 = nil,
- * 4-5 = this captbl,
- * 6-7 = our pgtbl root,
- * 8-11 = our component,
- * 12-13 = vm pte for booter
- * 14-15 = untyped memory pgtbl root,
- * 16-17 = vm pte for physical memory,
- * 18-19 = km pte,
- * 20-21 = comp0 captbl,
- * 22-23 = comp0 pgtbl root,
- * 24-27 = comp0 component,
- * 28~(20+2*NCPU) = per core alpha thd
+ * 4-7 = memory fault handler,
+ * 8-11 = divide by zero fault handler,
+ * 12-15 = breapoint fault handler,
+ * 16-19 = invaild instruction fault handler,
+ * 20-23 = bound exceed fault handler,
+ * 24-27 = component not exists fault handler,
+ * 28-31 = sinv to invaild component fault handler,
+ * 32-33 = this captbl,
+ * 34-35 = our pgtbl root,
+ * 36-39 = our component,
+ * 40-41 = vm pte for booter
+ * 42-43 = untyped memory pgtbl root,
+ * 44-45 = vm pte for physical memory,
+ * 46-47 = km pte,
+ * 48-49 = comp0 captbl,
+ * 50-51 = comp0 pgtbl root,
+ * 52-55 = comp0 component,
+ * 56~(48+2*NCPU) = per core alpha thd
  *
  * Initial pgtbl setup (addresses):
  * 1GB+8MB-> = boot component VM
  * 1.5GB-> = kernel memory
  * 2GB-> = system physical memory
  */
-enum
-{
-	BOOT_CAPTBL_SRET            = 0,
-	BOOT_CAPTBL_SELF_CT         = 4,
-	BOOT_CAPTBL_SELF_PT         = 6,
-	BOOT_CAPTBL_SELF_COMP       = 8,
-	BOOT_CAPTBL_BOOTVM_PTE      = 12,
-	BOOT_CAPTBL_SELF_UNTYPED_PT = 14,
-	BOOT_CAPTBL_PHYSM_PTE       = 16,
-	BOOT_CAPTBL_KM_PTE          = 18,
+ enum
+ {
+ 	BOOT_CAPTBL_SRET               = 0,
+ 	BOOT_CAPTBL_FLT_MEM            = 4,
+ 	BOOT_CAPTBL_FLT_DIVZERO        = 8,
+ 	BOOT_CAPTBL_FLT_BRKPT          = 12,
+ 	BOOT_CAPTBL_FLT_IVDINS         = 16,
+ 	BOOT_CAPTBL_FLT_BOUND_EXC      = 20,
+ 	BOOT_CAPTBL_FLT_COMP_NOT_EXIST = 24,
+	BOOT_CAPTBL_FLT_IVD_SINVCOMP   = 28,
+ 	BOOT_CAPTBL_SELF_CT            = 32,
+ 	BOOT_CAPTBL_SELF_PT            = 34,
+ 	BOOT_CAPTBL_SELF_COMP          = 36,
+ 	BOOT_CAPTBL_BOOTVM_PTE         = 40,
+ 	BOOT_CAPTBL_SELF_UNTYPED_PT    = 42,
+ 	BOOT_CAPTBL_PHYSM_PTE          = 44,
+ 	BOOT_CAPTBL_KM_PTE             = 46,
 
-	BOOT_CAPTBL_COMP0_CT           = 20,
-	BOOT_CAPTBL_COMP0_PT           = 22,
-	BOOT_CAPTBL_COMP0_COMP         = 24,
-	BOOT_CAPTBL_SINV_CAP           = 28,
-	BOOT_CAPTBL_SELF_INITTHD_BASE  = 32,
-	BOOT_CAPTBL_SELF_INITTCAP_BASE = BOOT_CAPTBL_SELF_INITTHD_BASE + NUM_CPU * CAP16B_IDSZ,
+ 	BOOT_CAPTBL_COMP0_CT           = 48,
+ 	BOOT_CAPTBL_COMP0_PT           = 50,
+ 	BOOT_CAPTBL_COMP0_COMP         = 52,
+ 	BOOT_CAPTBL_SINV_CAP           = 56,
+ 	BOOT_CAPTBL_SELF_INITTHD_BASE  = 60,
+ 	BOOT_CAPTBL_SELF_INITTCAP_BASE = BOOT_CAPTBL_SELF_INITTHD_BASE + NUM_CPU * CAP16B_IDSZ,
 	BOOT_CAPTBL_SELF_INITRCV_BASE  = round_up_to_pow2(BOOT_CAPTBL_SELF_INITTCAP_BASE + NUM_CPU * CAP16B_IDSZ,
                                                          CAPMAX_ENTRY_SZ),
 	BOOT_CAPTBL_SELF_INITHW_BASE   = round_up_to_pow2(BOOT_CAPTBL_SELF_INITRCV_BASE + NUM_CPU * CAP64B_IDSZ,

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -518,7 +518,7 @@ thd_invstk_push(struct thread *thd, struct comp_info *ci, unsigned long ip, unsi
 	top  = &thd->invstk[curr_invstk_top(cos_info) + 1];
 	curr_invstk_inc(cos_info);
 	prev->ip          = ip;
-	prev->sp 		  = sp;
+	prev->sp          = sp;
 	prev->fault_flag  = fault_flag;
 	memcpy(&top->comp_info, ci, sizeof(struct comp_info));
 	top->ip = top->sp = top->fault_flag = 0;

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -20,7 +20,7 @@
 
 struct invstk_entry {
 	struct comp_info comp_info;
-	unsigned long    sp, ip; /* to return to */
+	unsigned long    sp, ip, fault_flag; /* to return to */
 } HALF_CACHE_ALIGNED;
 
 #define THD_INVSTK_MAXSZ 32
@@ -485,6 +485,16 @@ thd_invstk_current(struct thread *curr_thd, unsigned long *ip, unsigned long *sp
 	return &curr->comp_info;
 }
 
+static inline struct comp_info *
+thd_invstk_current_fault(struct thread *curr_thd, unsigned long *ip, unsigned long *sp, unsigned long *fault_flag, struct cos_cpu_local_info *cos_info)
+{
+	struct invstk_entry *curr;
+
+	curr        = &curr_thd->invstk[curr_invstk_top(cos_info)];
+	*fault_flag = curr->fault_flag;
+	return thd_invstk_current(curr_thd, ip, sp, cos_info);
+}
+
 static inline pgtbl_t
 thd_current_pgtbl(struct thread *thd)
 {
@@ -497,7 +507,7 @@ thd_current_pgtbl(struct thread *thd)
 }
 
 static inline int
-thd_invstk_push(struct thread *thd, struct comp_info *ci, unsigned long ip, unsigned long sp,
+thd_invstk_push(struct thread *thd, struct comp_info *ci, unsigned long ip, unsigned long sp, unsigned long fault_flag,
                 struct cos_cpu_local_info *cos_info)
 {
 	struct invstk_entry *top, *prev;
@@ -507,20 +517,21 @@ thd_invstk_push(struct thread *thd, struct comp_info *ci, unsigned long ip, unsi
 	prev = &thd->invstk[curr_invstk_top(cos_info)];
 	top  = &thd->invstk[curr_invstk_top(cos_info) + 1];
 	curr_invstk_inc(cos_info);
-	prev->ip = ip;
-	prev->sp = sp;
+	prev->ip          = ip;
+	prev->sp 		  = sp;
+	prev->fault_flag  = fault_flag;
 	memcpy(&top->comp_info, ci, sizeof(struct comp_info));
-	top->ip = top->sp = 0;
+	top->ip = top->sp = top->fault_flag = 0;
 
 	return 0;
 }
 
 static inline struct comp_info *
-thd_invstk_pop(struct thread *thd, unsigned long *ip, unsigned long *sp, struct cos_cpu_local_info *cos_info)
+thd_invstk_pop(struct thread *thd, unsigned long *ip, unsigned long *sp, unsigned long *fault_flag, struct cos_cpu_local_info *cos_info)
 {
 	if (unlikely(curr_invstk_top(cos_info) == 0)) return NULL;
 	curr_invstk_dec(cos_info);
-	return thd_invstk_current(thd, ip, sp, cos_info);
+	return thd_invstk_current_fault(thd, ip, sp, fault_flag, cos_info);
 }
 
 static inline void

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -50,7 +50,6 @@ fault_handler_sinv(struct pt_regs *regs, capid_t cap)
 	regs->si = regs->ip;
 	regs->di = fault_addr;
 	regs->dx = cap;
-
 	fault_flag = 1;
 	if (likely(fh->type == CAP_SINV)){
 		sinv_call(curr_thd, (struct cap_sinv *)fh, regs, ci, fault_flag);

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -50,6 +50,7 @@ fault_handler_sinv(struct pt_regs *regs, capid_t cap)
 	regs->si = regs->ip;
 	regs->di = fault_addr;
 	regs->dx = cap;
+
 	fault_flag = 1;
 	if (likely(fh->type == CAP_SINV)){
 		sinv_call(curr_thd, (struct cap_sinv *)fh, regs, ci, fault_flag);

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -46,9 +46,10 @@ fault_handler_sinv(struct pt_regs *regs, capid_t cap)
 
 	fh = captbl_lkup(cos_info->captbl, cap);
 
-	regs->si  = regs->sp;
-	regs->di  = regs->ip;
-	regs->dx  = fault_addr;
+	regs->bx = regs->sp;
+	regs->si = regs->ip;
+	regs->di = fault_addr;
+	regs->dx = cap;
 
 	fault_flag = 1;
 	if (likely(fh->type == CAP_SINV)){

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -21,12 +21,50 @@ print_regs_state(struct pt_regs *regs)
 	PRINTK("(Exception Error Code-> ORIG_AX: %x)\n", regs->orig_ax);
 }
 
+static void
+fault_regs_save(struct pt_regs *regs, struct thread *thd)
+{
+	copy_all_regs(regs, &(thd->fault_regs));
+	PRINTK("Fault registers saved.\n");
+}
+
+int
+fault_handler_sinv(struct pt_regs *regs, capid_t cap)
+{
+	struct cos_cpu_local_info *ci       = cos_cpu_local_info();
+	struct thread             *curr_thd = thd_current(ci);
+	struct cap_header         *fh;
+	struct comp_info          *cos_info;
+	thdid_t                    thdid = curr_thd->tid;
+	unsigned long              ip, sp, fault_flag;
+	u32_t                      fault_addr = 0, errcode, eip;
+
+	print_regs_state(regs);
+	fault_regs_save (regs, curr_thd);
+
+	cos_info = thd_invstk_current(curr_thd, &ip, &sp, ci);
+
+	fh = captbl_lkup(cos_info->captbl, cap);
+
+	regs->si   = regs->sp;
+	regs->di   = regs->ip;
+	regs->dx   = fault_addr;
+
+	fault_flag = 1;
+	if (likely(fh->type == CAP_SINV)){
+		sinv_call(curr_thd, (struct cap_sinv *)fh, regs, ci, fault_flag);
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
 int
 div_by_zero_err_fault_handler(struct pt_regs *regs)
 {
-	print_regs_state(regs);
-	die("FAULT: Divide by Zero Error\n\n");
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_DIVZERO)) {
+		die("FAULT: Divide by Zero Error\n");
+	}
 	return 1;
 }
 
@@ -42,9 +80,9 @@ debug_trap_handler(struct pt_regs *regs)
 int
 breakpoint_trap_handler(struct pt_regs *regs)
 {
-	print_regs_state(regs);
-	die("TRAP: Breakpoint\n");
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_BRKPT)) {
+		die("TRAP: Breakpoint\n");
+	}
 	return 1;
 }
 
@@ -60,18 +98,18 @@ overflow_trap_handler(struct pt_regs *regs)
 int
 bound_range_exceed_fault_handler(struct pt_regs *regs)
 {
-	print_regs_state(regs);
-	die("FAULT: Bound Range Exceeded\n");
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_BOUND_EXC)) {
+		die("FAULT: Bound Range Exceeded\n");
+	}
 	return 1;
 }
 
 int
 invalid_opcode_fault_handler(struct pt_regs *regs)
 {
-	print_regs_state(regs);
-	die("FAULT: Invalid opcode\n");
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_IVDINS)) {
+		die("FAULT: Invalid opcode\n");
+	}
 	return 1;
 }
 
@@ -123,29 +161,18 @@ stack_seg_fault_handler(struct pt_regs *regs)
 int
 gen_protect_fault_handler(struct pt_regs *regs)
 {
-	print_regs_state(regs);
-	die("FAULT: General Protection Fault\n");
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_MEM)) {
+		die("FAULT: General Protection Fault\n");
+	}
 	return 1;
 }
 
 int
 page_fault_handler(struct pt_regs *regs)
 {
-	u32_t                      fault_addr, errcode = 0, eip = 0;
-	struct cos_cpu_local_info *ci    = cos_cpu_local_info();
-	thdid_t                    thdid = thd_current(ci)->tid;
-
-	print_regs_state(regs);
-	fault_addr = chal_cpu_fault_vaddr(regs);
-	errcode    = chal_cpu_fault_errcode(regs);
-	eip        = chal_cpu_fault_ip(regs);
-
-	die("FAULT: Page Fault in thd %d (%s %s %s %s %s) @ 0x%x, ip 0x%x\n", thdid,
-	    errcode & PGTBL_PRESENT ? "present" : "not-present",
-	    errcode & PGTBL_WRITABLE ? "write-fault" : "read-fault", errcode & PGTBL_USER ? "user-mode" : "system",
-	    errcode & PGTBL_WT ? "reserved" : "", errcode & PGTBL_NOCACHE ? "instruction-fetch" : "", fault_addr, eip);
-
+	if (!fault_handler_sinv(regs, BOOT_CAPTBL_FLT_MEM)) {
+		die("FAULT: Page Fault\n");
+	}
 	return 1;
 }
 

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -46,9 +46,9 @@ fault_handler_sinv(struct pt_regs *regs, capid_t cap)
 
 	fh = captbl_lkup(cos_info->captbl, cap);
 
-	regs->si   = regs->sp;
-	regs->di   = regs->ip;
-	regs->dx   = fault_addr;
+	regs->si  = regs->sp;
+	regs->di  = regs->ip;
+	regs->dx  = fault_addr;
 
 	fault_flag = 1;
 	if (likely(fh->type == CAP_SINV)){


### PR DESCRIPTION
### Summary of this Pull Request (PR)

This pull request is intended to get feedback of the implementation of fault handler. 

**Core related changes:**

1. Implemented 7 different fault handlers in the llbooter. When a fault happens the system will make a sinv call to the llbooter to handle the fault. Made an allocation of the sinv_cap of these fault handlers in the llbooter. The location of these sinv_caps in the captbl of each component have been hardcoded in cos_types.h.

2. Changed the sret_ret to make sure the system will use iret instead of sysexit when dealing with a fault. The registers will be restored before the fault is returned. I have added a 'fault_flag' in the invstk push and pop function to tell the sret_ret it is a normal sinv or a sinv of a fault handler.

3. Changed the exception.c file to save the fault regs and make a sinv call to the user-level fault handler. I have added a function called fault_handler_sinv which basically intended to reduce the redundancy of the code.

Now the user-level fault handler returns without and operation so the fault will repeat. I plan to kill the faulting thread to 'handle' the fault. 

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):

@gparmer , @hungry-foolish , @phanikishoreg 

### Code Quality

As part of this pull request, I've considered the following:

[Style]

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship]:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ ] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

I've used pingpong test to test my code. (If a fault happens in ping, the llbooter will be able to 'handle' it)
-
