### PR TITLE
Bring the 4th argument back.

### DIFF
--- a/src/components/implementation/no_interface/llbooter/boot_deps.h
+++ b/src/components/implementation/no_interface/llbooter/boot_deps.h
@@ -11,7 +11,7 @@
 #include <bitmap.h>
 
 /* Assembly function for sinv from new component */
-extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t *ret2, word_t *ret3);
+extern word_t hypercall_entry_rets_inv(spdid_t cur, int op, word_t arg1, word_t arg2, word_t arg3, word_t *ret2, word_t *ret3);
 
 extern int num_cobj;
 extern int capmgr_spdid;
@@ -601,7 +601,7 @@ __hypercall_resource_access_check(spdid_t dstid, spdid_t srcid, int capmgr_ignor
 }
 
 word_t
-hypercall_entry(word_t *ret2, word_t *ret3, int op, word_t arg3, word_t arg4)
+hypercall_entry(word_t *ret2, word_t *ret3, int op, word_t arg3, word_t arg4, word_t arg5)
 {
 	int ret1 = 0;
 	spdid_t client = cos_inv_token();

--- a/src/components/implementation/pong/pingpong/pong.c
+++ b/src/components/implementation/pong/pingpong/pong.c
@@ -42,9 +42,9 @@ call_arg(int p1)
 }
 
 void
-call_args(int p1, int p2, int p3)
+call_args(int p1, int p2, int p3, int p4)
 {
-	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%u. args: p1:%d p2:%d p3:%d\n", cos_inv_token(), p1, p2, p3);
+	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%u. args: p1:%d p2:%d p3:%d p4:%d\n", cos_inv_token(), p1, p2, p3, p4);
 	return;
 }
 

--- a/src/components/implementation/tests/unit_pingpong/ping.c
+++ b/src/components/implementation/tests/unit_pingpong/ping.c
@@ -7,7 +7,7 @@
 void cos_init(void)
 {
 	int r1 = 0, r2 = 0;
-	int a = 1, b = 2, c = 3;
+	int a = 1, b = 2, c = 3, d = 4;
 
 	PRINTLOG(PRINT_DEBUG, "Welcome to the ping component\n");
 
@@ -19,7 +19,7 @@ void cos_init(void)
 
 	PRINTLOG(PRINT_DEBUG, "Invoking pong interface w/ arguments:\n");
 	call_arg(a);
-	call_args(a, b, c);
+	call_args(a, b, c, d);
 
 	PRINTLOG(PRINT_DEBUG, "Invoking pong interface w/ multiple-rets:\n");
 	call_3rets(&r1, &r2, a, b, c);

--- a/src/components/include/cos_asm_server_stub_simple_stack.h
+++ b/src/components/include/cos_asm_server_stub_simple_stack.h
@@ -32,8 +32,9 @@ name##_inv:                        \
 	xor %ebp, %ebp;            \
 	pushl %edi;                \
 	pushl %esi;                \
+	pushl %ebx;                \
 	call name ;                \
-	addl $16, %esp;            \
+	addl $20, %esp;            \
 	                           \
 	movl %eax, %ecx;           \
 	movl $RET_CAP, %eax;       \
@@ -53,13 +54,14 @@ name##_rets_inv:                       \
 	xor %ebp, %ebp;		       \
 	pushl %edi;                    \
 	pushl %esi;                    \
+	pushl %ebx;                    \
 	movl %esp, %ecx;               \
-	addl $20, %ecx;                \
+	addl $24, %ecx;                \
 	pushl %ecx;                    \
 	subl $4, %ecx;                 \
 	pushl %ecx;                    \
 	call name ;                    \
-	addl $24, %esp;                \
+	addl $28, %esp;                \
 	popl %esi;                     \
 	popl %edi;                     \
 	                               \

--- a/src/components/include/hypercall.h
+++ b/src/components/include/hypercall.h
@@ -27,7 +27,7 @@ hypercall_comp_child_next(spdid_t c, spdid_t *child, comp_flag_t *flags)
 	word_t r2 = 0, r3 = 0;
 	int ret;
 
-	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CHILD_NEXT, c, 0, &r2, &r3);
+	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CHILD_NEXT, c, 0, 0, &r2, &r3);
 	if (ret < 0) return ret;
 	*child = (spdid_t)r2;
 	*flags = (comp_flag_t)r3;
@@ -42,7 +42,7 @@ hypercall_comp_init_done(void)
 	 * to be used only by the booter child threads
 	 * higher-level components use, schedinit interface to SINV to parent for init
 	 */
-	return cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INIT_DONE, 0, 0);
+	return cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INIT_DONE, 0, 0, 0);
 }
 
 /* Note: This API can be called ONLY by components that manage capability resources */
@@ -67,8 +67,8 @@ hypercall_comp_initaep_get(spdid_t spdid, int is_sched, struct cos_aep_info *aep
 	}
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret = cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INITAEP_GET,
-			spdid << 16 | thdslot, rcvslot << 16 | tcslot);
+	ret = cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INITAEP_GET,
+			spdid << 16 | thdslot, rcvslot << 16 | tcslot, 0);
 	if (ret) return ret;
 
 	aep->thd = thdslot;
@@ -95,8 +95,8 @@ hypercall_comp_info_get(spdid_t spdid, pgtblcap_t *ptslot, captblcap_t *ctslot, 
 	assert(*compslot);
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INFO_GET,
-			     spdid << 16 | (*compslot), (*ptslot) << 16 | (*ctslot), &r2, &r3);
+	ret = cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INFO_GET,
+			     spdid << 16 | (*compslot), (*ptslot) << 16 | (*ctslot), 0, &r2, &r3);
 	*parentid = r2;
 
 	return ret;
@@ -118,8 +118,8 @@ hypercall_comp_info_next(pgtblcap_t *ptslot, captblcap_t *ctslot, compcap_t *com
 	assert(*compslot);
 
 	/* capid_t though is unsigned long, only assuming it occupies 16bits for packing */
-	ret =  cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_INFO_NEXT,
-			      (*compslot), (*ptslot) << 16 | (*ctslot), &r2, &r3);
+	ret =  cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_INFO_NEXT,
+			      (*compslot), (*ptslot) << 16 | (*ctslot), 0, &r2, &r3);
 	*compid        = r2;
 	*comp_parentid = r3;
 
@@ -130,7 +130,7 @@ hypercall_comp_info_next(pgtblcap_t *ptslot, captblcap_t *ctslot, compcap_t *com
 static inline int
 hypercall_comp_frontier_get(spdid_t spdid, vaddr_t *vasfr, capid_t *capfr)
 {
-	return cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_FRONTIER_GET, spdid, 0, vasfr, capfr);
+	return cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_FRONTIER_GET, spdid, 0, 0, vasfr, capfr);
 }
 
 /* Note: This API can be called ONLY by components that manage capability resources */
@@ -142,7 +142,7 @@ hypercall_comp_compcap_get(spdid_t spdid)
 
 	assert(compslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_COMPCAP_GET, spdid, compslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_COMPCAP_GET, spdid, compslot, 0)) return 0;
 
 	return compslot;
 }
@@ -156,7 +156,7 @@ hypercall_comp_captblcap_get(spdid_t spdid)
 
 	assert(ctslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CAPTBLCAP_GET, spdid, ctslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CAPTBLCAP_GET, spdid, ctslot, 0)) return 0;
 
 	return ctslot;
 }
@@ -170,7 +170,7 @@ hypercall_comp_pgtblcap_get(spdid_t spdid)
 
 	assert(ptslot);
 
-	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_PGTBLCAP_GET, spdid, ptslot)) return 0;
+	if (cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_PGTBLCAP_GET, spdid, ptslot, 0)) return 0;
 
 	return ptslot;
 }
@@ -181,7 +181,7 @@ hypercall_comp_capfrontier_get(spdid_t spdid)
 	word_t unused;
 	capid_t cap_frontier;
 
-	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CAPFRONTIER_GET, spdid, 0, &cap_frontier, &unused)) return 0;
+	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CAPFRONTIER_GET, spdid, 0, 0, &cap_frontier, &unused)) return 0;
 
 	return cap_frontier;
 }
@@ -189,7 +189,7 @@ hypercall_comp_capfrontier_get(spdid_t spdid)
 static inline int
 hypercall_numcomps_get(void)
 {
-	return cos_sinv(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_NUMCOMPS_GET, 0, 0);
+	return cos_sinv(BOOT_CAPTBL_SINV_CAP, HYPERCALL_NUMCOMPS_GET, 0, 0, 0);
 }
 
 #endif /* HYPERCALL_H */

--- a/src/components/interface/pong/pong.h
+++ b/src/components/interface/pong/pong.h
@@ -7,7 +7,7 @@ void call_three(void);
 void call_four(void);
 
 void call_arg(int p1);
-void call_args(int p1, int p2, int p3);
+void call_args(int p1, int p2, int p3, int p4);
 
 void call_3rets(int *r2, int *r3, int p1, int p2, int p3);
 

--- a/src/components/lib/c_stub.c
+++ b/src/components/lib/c_stub.c
@@ -33,11 +33,11 @@ SS_ipc_client_fault(cos_flt_off flt)
 __attribute__((regparm(1))) int
 SS_ipc_client_marshal_args(struct usr_inv_cap *uc, long p0, long p1, long p2, long p3)
 {
-	return cos_sinv(uc->cap_no, 0, p0, p1, p2);
+	return cos_sinv(uc->cap_no, p0, p1, p2, p3);
 }
 
 __attribute__((regparm(1))) int
 SS_ipc_client_marshal_args_rets(struct usr_inv_cap *uc, long *r2, long *r3, long p0, long p1, long p2, long p3)
 {
-	return cos_sinv_rets(uc->cap_no, 0, p0, p1, p2, (word_t *)r2, (word_t *)r3);
+	return cos_sinv_rets(uc->cap_no, p0, p1, p2, p3, (word_t *)r2, (word_t *)r3);
 }


### PR DESCRIPTION
### Summary of this Pull Request (PR)

This PR trying to bring the 4th argument back. I have done this PR according to one of @phanikishoreg 's commits the hash number is [e09e0ce](https://github.com/gwsystems/composite/commit/e09e0cedf1af23a1503275a6200ee165c9dee826)

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)
@gparmer , @phanikishoreg , @hungry-foolish 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):
I have run llbooter_pong.sh, llbooter_test.sh, unit_schedcomp.sh, unit_schedtest.sh, microbooter.sh, unit_fprr.sh.
