### PR TITLE
Enabling micro_booter tests, other bugfixes

### DIFF
--- a/src/components/implementation/pong/pingpong/pong.c
+++ b/src/components/implementation/pong/pingpong/pong.c
@@ -44,7 +44,7 @@ call_arg(int p1)
 void
 call_args(int p1, int p2, int p3, int p4)
 {
-	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%u. args: p1:%d p2:%d p3:%d p4:%d\n", cos_inv_token(), p1, p2, p3, p4);
+	PRINTLOG(PRINT_DEBUG, "In call_args() in pong interface, client:%lu. args: p1:%d p2:%d p3:%d p4:%d\n", cos_inv_token(), p1, p2, p3, p4);
 	return;
 }
 

--- a/src/components/implementation/sched/sched_info.c
+++ b/src/components/implementation/sched/sched_info.c
@@ -85,7 +85,6 @@ sched_childinfo_init_intern(int is_raw)
 		struct sl_thd          *initthd   = NULL;
 		compcap_t               compcap   = 0;
 
-		PRINTLOG(PRINT_DEBUG, "Initializing child component %u, is_sched=%d\n", child, childflags & COMP_FLAG_SCHED);
 		if (is_raw) {
 			compcap = hypercall_comp_compcap_get(child);
 			assert(compcap);
@@ -97,6 +96,7 @@ sched_childinfo_init_intern(int is_raw)
 		hypercall_comp_cpubitmap_get(child, schedinfo->cpubmp);
 
 		if (bitmap_check(schedinfo->cpubmp, cos_cpuid())) {
+			PRINTLOG(PRINT_DEBUG, "Initializing child component %u, is_sched=%d\n", child, childflags & COMP_FLAG_SCHED);
 			initthd = sl_thd_initaep_alloc(child_dci, NULL, childflags & COMP_FLAG_SCHED, childflags & COMP_FLAG_SCHED ? 1 : 0, 0, 0, 0); /* TODO: rate information */
 			assert(initthd);
 			sched_child_initthd_set(schedinfo, initthd);

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -911,22 +911,22 @@ test_run_mb(void)
 {
 	cyc_per_usec = cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE);
 
-	test_ipi();
-//	test_timer();
-//	test_budgets();
-//
-//	test_thds();
-//	test_thds_perf();
-//
-//	test_mem();
-//
-//	test_async_endpoints();
-//	test_async_endpoints_perf();
-//
-//	test_inv();
-//	test_inv_perf();
-//
-//	test_captbl_expand();
+	/* test_ipi(); */
+	test_timer();
+	test_budgets();
+
+	test_thds();
+	test_thds_perf();
+
+	test_mem();
+
+	test_async_endpoints();
+	test_async_endpoints_perf();
+
+	test_inv();
+	test_inv_perf();
+
+	test_captbl_expand();
 
 	/*
 	 * FIXME: Preemption stack mechanism in the kernel is disabled.

--- a/src/components/implementation/tests/micro_ipi/micro_ipi.c
+++ b/src/components/implementation/tests/micro_ipi/micro_ipi.c
@@ -13,7 +13,8 @@
 #include <hypercall.h>
 
 /* enable only one of these */
-#define TEST_LATENCY
+#define TEST_IPC
+#undef TEST_LATENCY
 #undef TEST_RATE
 
 #define HI_PRIO TCAP_PRIO_MAX
@@ -23,7 +24,7 @@
 #define AEP_PERIOD_US 10000
 
 #define IPI_MIN_THRESH 300
-#define IPI_TEST_ITERS 1000000
+#define IPI_TEST_ITERS 10000
 #define SCHED_PERIOD_US 100000 /* 100ms */
 
 static volatile cycles_t last = 0, total = 0, wc = 0, pwc = 0;
@@ -403,7 +404,132 @@ test_rate_setup(void)
 #endif
 }
 
-#define MICRO_IPI_FIRST_RUN
+volatile cycles_t c0_start = 0, c0_end = 0, c0_mid = 0, c1_start = 0, c1_end = 0, c1_mid = 0;
+
+#define TEST_IPC_ITERS 100
+
+static void
+c0_ipc_fn(arcvcap_t r, void *d)
+{
+	asndcap_t snd = c0_cn_asnd[cos_cpuid()];
+	int iters;
+	cycles_t rtt_total = 0, one_total = 0, rtt_wc = 0, one_wc = 0, rone_total = 0, rone_wc = 0;
+
+	PRINTC("Testing Cross-core IPC:\n");
+	assert(snd);
+	rdtscll(c0_start);
+	c0_end = c0_mid = c1_start = c1_mid = c1_end = c0_start;
+
+	testing = 1;
+
+	while (1) {
+		int pending = 0, rcvd = 0, ret = 0;
+		cycles_t rtt_diff, one_diff = 0, rone_diff = 0;
+
+		rdtscll(c0_start);
+		ret = cos_asnd(snd, 0);
+		assert(ret == 0);
+
+		rdtscll(c0_mid);
+		pending = cos_rcv(r, RCV_ALL_PENDING, &rcvd);
+		assert(pending == 0 && rcvd == 1);
+		rdtscll(c0_end);
+
+		rtt_diff = (c0_end - c0_start);
+		one_diff = (c1_mid - c0_start);
+		rone_diff = (c0_end - c1_mid);
+		if (rtt_diff > rtt_wc) rtt_wc = rtt_diff;
+		if (one_diff > one_wc) one_wc = one_diff;
+		if (rone_diff > rone_wc) rone_wc = rone_diff;
+		rtt_total += rtt_diff;
+		one_total += one_diff;
+		rone_total += rone_diff;
+
+		iters++;
+		if (iters >= TEST_IPC_ITERS) break;
+	}
+
+	testing = 0;
+	PRINTC("IPC RTT = AVG: %llu, WC: %llu, ITERS: %d\n", rtt_total / iters, rtt_wc, iters);
+	PRINTC("IPC ONEWAY = AVG: %llu, WC: %llu, ITERS: %d\n", one_total / iters, one_wc, iters);
+	PRINTC("IPC ONEWAY (RET) = AVG: %llu, WC: %llu, ITERS: %d\n", rone_total / iters, rone_wc, iters);
+
+	sl_thd_exit();
+}
+
+static void
+c1_ipc_fn(arcvcap_t r, void *d)
+{
+	asndcap_t snd = cn_c0_asnd[cos_cpuid()];
+
+	assert(snd);
+	while (testing == 0) ;
+
+	while (1) {
+		int pending = 0, rcvd = 0, ret = 0;
+
+		if (unlikely(testing == 0)) break;
+
+		rdtscll(c1_start);
+		pending = cos_rcv(r, RCV_ALL_PENDING, &rcvd);
+		assert(pending == 0 && rcvd == 1);
+
+		rdtscll(c1_mid);
+		ret = cos_asnd(snd, 0);
+		assert(ret == 0);
+		rdtscll(c1_end);
+	}
+
+	sl_thd_exit();
+}
+
+static void
+test_ipc_setup(void)
+{
+#ifdef TEST_IPC
+	static volatile int cdone[NUM_CPU] = { 0 };
+	int i, ret;
+	struct sl_thd *t = NULL;
+	asndcap_t snd = 0;
+
+	assert(NUM_CPU == 2); /* use only 2 cores for this test! */
+
+	if (cos_cpuid() == 0) {
+		t = sl_thd_aep_alloc(c0_ipc_fn, (void *)cos_cpuid(), 1, 0, 0, 0);
+		assert(t);
+		c0_rcv[cos_cpuid()] = sl_thd_rcvcap(t);
+
+		while (!cn_rcv[1]) ;
+
+		snd = capmgr_asnd_rcv_create(cn_rcv[1]);
+		assert(snd);
+		c0_cn_asnd[cos_cpuid()] = snd;
+	} else {
+		t = sl_thd_aep_alloc(c1_ipc_fn, (void *)cos_cpuid(), 1, 0, 0, 0);
+		assert(t);
+		cn_rcv[cos_cpuid()] = sl_thd_rcvcap(t);
+
+		while (!c0_rcv[0]) ;
+
+		snd = capmgr_asnd_rcv_create(c0_rcv[0]);
+		assert(snd);
+		cn_c0_asnd[cos_cpuid()] = snd;
+	}
+
+	ret = cos_tcap_transfer(sl_thd_rcvcap(t), BOOT_CAPTBL_SELF_INITTCAP_CPU_BASE, TCAP_RES_INF, LOW_PRIO);
+	assert(ret == 0);
+	sl_thd_param_set(t, sched_param_pack(SCHEDP_WINDOW, AEP_PERIOD_US));
+	sl_thd_param_set(t, sched_param_pack(SCHEDP_BUDGET, AEP_BUDGET_US));
+	sl_thd_param_set(t, sched_param_pack(SCHEDP_PRIO, LOW_PRIO));
+
+	ps_faa((unsigned long *)&cdone[cos_cpuid()], 1);
+	for (i = 0; i < NUM_CPU; i++) {
+		while (!ps_load((unsigned long *)&cdone[i])) ;
+	}
+#endif
+}
+
+#undef MICRO_IPI_FIRST_RUN
 
 void
 cos_init(void)
@@ -419,12 +545,14 @@ cos_init(void)
 		cos_meminfo_init(&(ci->mi), BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
 		cos_defcompinfo_init();
 
+#ifndef TEST_IPC
 #ifdef MICRO_IPI_FIRST_RUN
 		PRINTC("MAKE SURE YOU MODIFY SL FOR THE FOLLOWING TEST TO WORK WELL\n");
 		PRINTC("MAKE SURE YOU DON'T RUN IDLE THREAD IF NO THREAD IS READY TO RUN\n");
 		PRINTC("SET TIMEOUT PARAM IN ALL COS_SWITCH TO 0. THIS IS DONE BY SETTING timeout_next to 0 IN SL\n");
 		PRINTC("ONCE YOU DO ALL THAT, UNDEF FIRST_RUN AND RECOMPILE. :-)\n");
 		assert(0);
+#endif
 #endif
 	} else {
 		while (!ps_load(&init_done[first])) ;
@@ -439,6 +567,7 @@ cos_init(void)
 	sl_init(SCHED_PERIOD_US);
         hypercall_comp_init_done();
 
+	test_ipc_setup();
 	test_latency_setup();
 	test_rate_setup();
 

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -225,33 +225,37 @@ cos_init_args(void)
 	return cos_comp_info.init_string;
 }
 
-#define COS_CPUBITMAP_STARTTOK "cpu="
+#define COS_CPUBITMAP_STARTTOK 'c'
 #define COS_CPUBITMAP_ENDTOK   ","
 #define COS_CPUBITMAP_LEN      (NUM_CPU)
 
 static inline int
 cos_args_cpubmp(u32_t *cpubmp, char *arg)
 {
-	char *start = NULL;
-	char restr[COMP_INFO_INIT_STR_LEN] = { '\0' }, *rs = restr;
+	char *tok1 = NULL, *tok2 = NULL;
+	char res[COMP_INFO_INIT_STR_LEN] = { '\0' }, *rs = res;
 	int i, len = 0;
 
 	if (!arg || !cpubmp) return -EINVAL;
-	strncpy(restr, arg, COMP_INFO_INIT_STR_LEN);
-	/* if "cpu=" tag is not present.. set the component to be runnable on all cores */
-	if (!strlen(arg) || !(start = strtok_r(rs, COS_CPUBITMAP_STARTTOK, &rs))) {
-		bitmap_set_contig(cpubmp, 0, NUM_CPU, 1);
-
-		return 0;
+	strncpy(rs, arg, COMP_INFO_INIT_STR_LEN);
+	if (!strlen(arg)) goto allset;
+	while ((tok1 = strtok_r(rs, COS_CPUBITMAP_ENDTOK, &rs)) != NULL) {
+		if (tok1[0] == COS_CPUBITMAP_STARTTOK) break;
 	}
-	if (strlen(start) < COS_CPUBITMAP_LEN + 1) return -EINVAL;
-	if (strncmp(start + COS_CPUBITMAP_LEN, COS_CPUBITMAP_ENDTOK, strlen(COS_CPUBITMAP_ENDTOK)) != 0) return -EINVAL;
-	*(start + COS_CPUBITMAP_LEN) = '\0';
+	/* if "c" tag is not present.. set the component to be runnable on all cores */
+	if (!tok1) goto allset;
+	if (strlen(tok1) != (COS_CPUBITMAP_LEN + 1)) return -EINVAL;
 
-	len = strlen(start);
+	tok2 = tok1 + 1;
+	len = strlen(tok2);
 	for (i = 0; i < len; i++) {
-		if (start[i] == '1') bitmap_set(cpubmp, (len - 1 - i));
+		if (tok2[i] == '1') bitmap_set(cpubmp, (len - 1 - i));
 	}
+
+	return 0;
+
+allset:
+	bitmap_set_contig(cpubmp, 0, NUM_CPU, 1);
 
 	return 0;
 }

--- a/src/components/include/hypercall.h
+++ b/src/components/include/hypercall.h
@@ -194,7 +194,7 @@ hypercall_comp_cpubitmap_get(spdid_t spdid, u32_t *bmp)
 
 	assert(NUM_CPU_BMP_WORDS <= 2); /* FIXME: works for up to 64 cores */
 
-	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, 0, HYPERCALL_COMP_CPUBITMAP_GET, spdid, 0, &lo, &hi)) return -1;
+	if (cos_sinv_rets(BOOT_CAPTBL_SINV_CAP, HYPERCALL_COMP_CPUBITMAP_GET, spdid, 0, 0, &lo, &hi)) return -1;
 
 	bmp[0] = lo;
 	if (NUM_CPU_BMP_WORDS == 2) bmp[1] = hi;

--- a/src/components/lib/sinv_async/sinv_server.c
+++ b/src/components/lib/sinv_async/sinv_server.c
@@ -129,7 +129,7 @@ sinv_server_aep_fn(arcvcap_t rcv, void *data)
 		ret = ps_cas((unsigned long *)reqaddr, SINV_REQ_SET, SINV_REQ_RESET); /* indicate request completion */
 		assert(ret);
 
-		if (snd) cos_asnd(snd, 1);
+		/* if (snd) cos_asnd(snd, 1); */
 	}
 }
 

--- a/src/platform/i386/runscripts/unit_srvdummy_xcore.sh
+++ b/src/platform/i386/runscripts/unit_srvdummy_xcore.sh
@@ -6,4 +6,4 @@ cp root_fprr.o boot.o
 # srvdummy_server and srvdummy_stubcomp run on core 1
 # this tests cross core SINV => async requests
 # to test this, set NUM_CPU to 2 in cos_config.h or remove 'cpu=xx,' args in the below line.
-./cos_linker "llboot.o, ;*srvdummy_client.o,'cpu=01,';capmgr.o, ;*srvdummy_server.o,'cpu=10,';*boot.o, ;srvdummy_stubcomp.o,'cpu=10,';unitsrvdummy.o,'cpu=01,':boot.o-capmgr.o;srvdummy_client.o-capmgr.o|[parent_]boot.o;srvdummy_server.o-capmgr.o|[parent_]boot.o;unitsrvdummy.o-srvdummy_client.o;srvdummy_stubcomp.o-capmgr.o|srvdummy_server.o" ./gen_client_stub
+./cos_linker "llboot.o, ;*srvdummy_client.o,'c01';capmgr.o, ;*srvdummy_server.o,'c10';*boot.o, ;srvdummy_stubcomp.o, ;unitsrvdummy.o, :boot.o-capmgr.o;srvdummy_client.o-capmgr.o|[parent_]boot.o;srvdummy_server.o-capmgr.o|[parent_]boot.o;unitsrvdummy.o-srvdummy_client.o;srvdummy_stubcomp.o-capmgr.o|srvdummy_server.o" ./gen_client_stub


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Well, I had the standard micro booter tests disabled in my last PR. Fixing that!

There are other merge fixes that I'm fixing along with it. 
Also added Cross-core IPC ubench to micro_ipi. This should help in test the `micro_ipisched.sh` to understand the cross-core usage well.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ ] I've made an attempt to remove all redundant code: **My PR #354 is huge and is merged without a review so I don't want to check this because I've not made any attempt to remove other redundant code outside the scope of this PR.**
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- micro_booter on qemu with NUM_CPU set to 1 and 2.
- unit_srvdummy_xcore.sh with 2cores - this is to test the sinv_async library.
- micro_ipisched for cross-core IPC with 2 cores - this is testing the IPC costs for cross-core asnd (with capmgr inv)+arcv.