### PR TITLE
User-level thread dispatch on x86

### DIFF
--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -52,6 +52,6 @@ SERVER_STUB=s_stub.o
 CLIENT_STUB=c_stub.o
 
 LIBCOSDEFKERN=-lcos_kernel_api -lcos_defkernel_api
-LIBSLCORE=$(LIBCOSDEFKERN) -lsl_sched -lheap -lsl_xcpu -lsl_child -lck
+LIBSLCORE=$(LIBCOSDEFKERN) -lsl_sched -lheap -lsl_xcpu -lsl_child -lck -lsl_slowpath
 LIBSLCAPMGR=$(LIBSLCORE) -lsl_capmgr
 LIBSLRAW=$(LIBSLCORE) -lsl_raw

--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -53,5 +53,5 @@ CLIENT_STUB=c_stub.o
 
 LIBCOSDEFKERN=-lcos_kernel_api -lcos_defkernel_api
 LIBSLCORE=$(LIBCOSDEFKERN) -lsl_sched -lheap -lsl_xcpu -lsl_child -lck -lsl_slowpath
-LIBSLCAPMGR=$(LIBSLCORE) -lsl_capmgr
-LIBSLRAW=$(LIBSLCORE) -lsl_raw
+LIBSLCAPMGR=$(LIBSLCORE) -lsl_capmgr -lcos_dcbcapmgr
+LIBSLRAW=$(LIBSLCORE) -lsl_raw -lcos_dcbraw

--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -52,6 +52,6 @@ SERVER_STUB=s_stub.o
 CLIENT_STUB=c_stub.o
 
 LIBCOSDEFKERN=-lcos_kernel_api -lcos_defkernel_api
-LIBSLCORE=$(LIBCOSDEFKERN) -lsl_sched -lheap -lsl_xcpu -lsl_child -lck -lsl_slowpath
+LIBSLCORE=$(LIBCOSDEFKERN) -lsl_sched -lheap -lsl_xcpu -lsl_child -lck
 LIBSLCAPMGR=$(LIBSLCORE) -lsl_capmgr -lcos_dcbcapmgr
 LIBSLRAW=$(LIBSLCORE) -lsl_raw -lcos_dcbraw

--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -40,9 +40,9 @@ LUAINC=-I$(LUADIR)/src -I$(LUABASE)/cos/include
 
 INC_PATH=-I./ -I$(CDIR)/include/ -I$(CDIR)/interface/ -I$(SHAREDINC) -I$(CKINCDIR)
 SHARED_FLAGS=-fno-merge-constants -nostdinc -nostdlib -fno-pic
-OPT= -g
-#OPT= -O3
-CFLAGS=-m32 -D__x86__ -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -fno-stack-protector -fno-omit-frame-pointer -Wno-unused-variable -fvar-tracking $(INC_PATH) $(MUSLINC) $(LWIPINC) $(LUAINC) $(OPT) $(SHARED_FLAGS)
+OPT= -g -fvar-tracking
+OPT= -O3
+CFLAGS=-m32 -D__x86__ -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -fno-stack-protector -fno-omit-frame-pointer -Wno-unused-variable $(INC_PATH) $(MUSLINC) $(LWIPINC) $(LUAINC) $(OPT) $(SHARED_FLAGS)
 CXXFLAGS=-fno-exceptions -fno-threadsafe-statics -Wno-write-strings $(CFLAGS)
 LDFLAGS=-melf_i386
 MUSLCFLAGS=$(CFLAGS) -lc -lgcc -Xlinker -r

--- a/src/components/implementation/capmgr/naive/cap_info.c
+++ b/src/components/implementation/capmgr/naive/cap_info.c
@@ -225,7 +225,8 @@ cap_shmem_region_find(cos_channelkey_t key)
 	cbuf_t i, free = rglb->free_region_id;
 
 	for (i = 1; i <= free; i++) {
-		if (ps_load((unsigned long *)&rglb->region_keys[i - 1]) == key) {
+		cos_channelkey_t *k = &rglb->region_keys[i - 1];
+		if (ps_load((unsigned long *)k) == (unsigned long)key) {
 			id = i;
 			break;
 		}

--- a/src/components/implementation/capmgr/naive/cap_info.h
+++ b/src/components/implementation/capmgr/naive/cap_info.h
@@ -43,6 +43,8 @@ struct cap_comp_cpu_info {
 	int p_thd_iterator; /* iterator for parent to get all threads created by capmgr in this component so far! */
 	thdcap_t p_initthdcap; /* init thread's cap in parent */
 	thdid_t  initthdid; /* init thread's tid */
+
+	vaddr_t  initdcbpg;
 } CACHE_ALIGNED;
 
 struct cap_comp_info {

--- a/src/components/implementation/capmgr/naive/mem_mgr.c
+++ b/src/components/implementation/capmgr/naive/mem_mgr.c
@@ -24,6 +24,36 @@ memmgr_heap_page_allocn(unsigned long npages)
 	return dst_pg;
 }
 
+vaddr_t
+memmgr_dcbpage_allocn(unsigned long npages)
+{
+	spdid_t cur = cos_inv_token();
+	struct cos_compinfo  *cap_ci  = cos_compinfo_get(cos_defcompinfo_curr_get());
+	struct cap_comp_info *cur_rci = cap_info_comp_find(cur);
+	struct cos_compinfo  *cur_ci  = cap_info_ci(cur_rci);
+	vaddr_t pg;
+
+	if (!cur_rci || !cap_info_init_check(cur_rci)) return 0;
+	if (!cur_ci) return 0;
+
+	pg = (vaddr_t)cos_dcbpg_bump_allocn(cur_ci, npages * PAGE_SIZE);
+
+	return pg;
+}
+
+vaddr_t
+memmgr_initdcbpage_retrieve(void)
+{
+	spdid_t cur = cos_inv_token();
+	struct cap_comp_info *cur_rci     = cap_info_comp_find(cur);
+	struct cap_comp_cpu_info *rci_cpu = cap_info_cpu_local(cur_rci);
+
+	/* this should have been initialized either through the booter for capmgr/root-sched or by the capmgr on inithrd creation in cur component */
+	assert(rci_cpu->initdcbpg);
+
+	return rci_cpu->initdcbpg;
+}
+
 cbuf_t
 memmgr_shared_page_allocn_cserialized(vaddr_t *pgaddr, int *unused, unsigned long npages)
 {

--- a/src/components/implementation/no_interface/llbooter/llbooter.c
+++ b/src/components/implementation/no_interface/llbooter/llbooter.c
@@ -214,15 +214,17 @@ boot_comp_map_populate(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info)
 		}
 
 		if (sect->flags & COBJ_SECT_CINFO) {
+			int k;
+
 			assert((left % PAGE_SIZE) == 0);
 			assert(comp_info == (dest_daddr + (((left/PAGE_SIZE)-1)*PAGE_SIZE)));
 			boot_process_cinfo(h, spdid, boot_spd_end(h), start_addr + (comp_info - init_daddr), comp_info);
 			ci = (struct cos_component_information *)(start_addr + (comp_info - init_daddr));
+			spdinfo->cobj_info = ci;
 
 			hinfo = boot_spd_compcapinfo_get(h->id);
 			hinfo->upcall_entry = ci->cos_upcall_entry;
 		}
-
 	}
 
 	return 0;

--- a/src/components/implementation/no_interface/vkernel/micro_booter.h
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.h
@@ -47,4 +47,7 @@ tls_set(size_t off, unsigned long val)
 
 extern void test_run_vk(void);
 
+void cos_dcb_info_init(void);
+struct cos_dcb_info *cos_dcb_info_get(void);
+
 #endif /* MICRO_BOOTER_H */

--- a/src/components/implementation/no_interface/vkernel/vk_api.c
+++ b/src/components/implementation/no_interface/vkernel/vk_api.c
@@ -1,3 +1,4 @@
+#include <cos_dcb.h>
 #include "vk_api.h"
 
 extern vaddr_t cos_upcall_entry;
@@ -5,6 +6,12 @@ extern vaddr_t cos_upcall_entry;
 extern void vm_init(void *);
 extern void dom0_io_fn(void *);
 extern void vm_io_fn(void *);
+
+struct cos_dcb_info *
+cos_dcb_info_get(void)
+{
+	return cos_dcb_info_assign();
+}
 
 static struct cos_aep_info *
 vm_schedaep_get(struct vms_info *vminfo)
@@ -19,6 +26,7 @@ vk_vm_create(struct vms_info *vminfo, struct vkernel_info *vkinfo)
 	struct cos_aep_info    *initaep  = cos_sched_aep_get(vmdci);
 	pgtblcap_t              vmutpt;
 	int                     ret;
+	vaddr_t                 scbpg, initdcbpg;
 
 	assert(vminfo && vkinfo);
 
@@ -27,7 +35,7 @@ vk_vm_create(struct vms_info *vminfo, struct vkernel_info *vkinfo)
 
 	cos_meminfo_init(&(vmcinfo->mi), BOOT_MEM_KM_BASE, VM_UNTYPED_SIZE, vmutpt);
 	ret = cos_defcompinfo_child_alloc(vmdci, (vaddr_t)&cos_upcall_entry, (vaddr_t)BOOT_MEM_VM_BASE,
-					  VM_CAPTBL_FREE, 1);
+					  VM_CAPTBL_FREE, 1, &initdcbpg, &scbpg);
 	cos_compinfo_init(&(vminfo->shm_cinfo), vmcinfo->pgtbl_cap, vmcinfo->captbl_cap, vmcinfo->comp_cap,
 			  (vaddr_t)VK_VM_SHM_BASE, VM_CAPTBL_FREE, vk_cinfo);
 
@@ -99,7 +107,7 @@ vk_vm_io_init(struct vms_info *vminfo, struct vms_info *dom0info, struct vkernel
 	assert(vminfo->id && !dom0info->id);
 	assert(vmidx >= 0 && vmidx <= VM_COUNT - 1);
 
-	d0io->iothds[vmidx] = cos_thd_alloc(vkcinfo, d0cinfo->comp_cap, dom0_io_fn, (void *)vminfo->id);
+	d0io->iothds[vmidx] = cos_thd_alloc(vkcinfo, d0cinfo->comp_cap, dom0_io_fn, (void *)vminfo->id, 0, 0);
 	assert(d0io->iothds[vmidx]);
 	d0io->iotcaps[vmidx] = cos_tcap_alloc(vkcinfo);
 	assert(d0io->iotcaps[vmidx]);
@@ -113,7 +121,7 @@ vk_vm_io_init(struct vms_info *vminfo, struct vms_info *dom0info, struct vkernel
 	ret = cos_cap_cpy_at(d0cinfo, dom0_vio_rcvcap(vminfo->id), vkcinfo, d0io->iorcvs[vmidx]);
 	assert(ret == 0);
 
-	vio->iothd = cos_thd_alloc(vkcinfo, vmcinfo->comp_cap, vm_io_fn, (void *)vminfo->id);
+	vio->iothd = cos_thd_alloc(vkcinfo, vmcinfo->comp_cap, vm_io_fn, (void *)vminfo->id, 0, 0);
 	assert(vio->iothd);
 	vio->iorcv = cos_arcv_alloc(vkcinfo, vio->iothd, vmaep->tc, vkcinfo->comp_cap, vmaep->rcv);
 	assert(vio->iorcv);

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -53,7 +53,7 @@ cos_init(void)
 	cos_compinfo_init(&vk_info.shm_cinfo, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
 			  (vaddr_t)VK_VM_SHM_BASE, BOOT_CAPTBL_FREE, ci);
 
-	vk_info.termthd = cos_thd_alloc(vk_cinfo, vk_cinfo->comp_cap, vk_terminate, NULL);
+	vk_info.termthd = cos_thd_alloc(vk_cinfo, vk_cinfo->comp_cap, vk_terminate, NULL, 0, 0);
 	assert(vk_info.termthd);
 
 	vk_info.sinv = cos_sinv_alloc(vk_cinfo, vk_cinfo->comp_cap, (vaddr_t)__inv_vkernel_hypercallfn, 0);

--- a/src/components/implementation/sched/sched.c
+++ b/src/components/implementation/sched/sched.c
@@ -50,7 +50,7 @@ sched_thd_create_cserialized(thdclosure_index_t idx)
 	dci = sched_child_defci_get(sched_childinfo_find(c));
 	if (!dci) return 0;
 
-	t = sl_thd_aep_alloc_ext(dci, NULL, idx, 0, 0, 0, NULL);
+	t = sl_thd_aep_alloc_ext(dci, NULL, idx, 0, 0, 0, 0, NULL);
 	if (!t) return 0;
 
 	return sl_thd_thdid(t);
@@ -67,7 +67,7 @@ sched_aep_create_cserialized(arcvcap_t *extrcv, int *unused, thdclosure_index_t 
 	dci = sched_child_defci_get(sched_childinfo_find(c));
 	if (!dci) return 0;
 
-	t = sl_thd_aep_alloc_ext(dci, NULL, idx, 1, owntc, key, extrcv);
+	t = sl_thd_aep_alloc_ext(dci, NULL, idx, 1, owntc, key, 0, extrcv);
 	if (!t) return 0;
 
 	return sl_thd_thdid(t);

--- a/src/components/implementation/sched/sched_info.c
+++ b/src/components/implementation/sched/sched_info.c
@@ -90,7 +90,7 @@ sched_childinfo_init_intern(int is_raw)
 		assert(schedinfo);
 		child_dci = sched_child_defci_get(schedinfo);
 
-		initthd = sl_thd_initaep_alloc(child_dci, NULL, childflags & COMP_FLAG_SCHED, childflags & COMP_FLAG_SCHED ? 1 : 0, 0);
+		initthd = sl_thd_initaep_alloc(child_dci, NULL, childflags & COMP_FLAG_SCHED, childflags & COMP_FLAG_SCHED ? 1 : 0, 0, 0);
 		assert(initthd);
 		sched_child_initthd_set(schedinfo, initthd);
 

--- a/src/components/implementation/tests/micro_booter/micro_booter.h
+++ b/src/components/implementation/tests/micro_booter/micro_booter.h
@@ -30,6 +30,7 @@
 #define ITER 10000
 #define TEST_NTHDS 5
 
+extern struct cos_dcb_info *init_dcbinfo[];
 extern struct cos_compinfo booter_info;
 extern thdcap_t            termthd[]; /* switch to this to shutdown */
 extern unsigned long       tls_test[][TEST_NTHDS];
@@ -52,5 +53,8 @@ tls_set(size_t off, unsigned long val)
 }
 
 extern void test_run_mb(void);
+
+void cos_dcb_info_init(void);
+struct cos_dcb_info *cos_dcb_info_get(void);
 
 #endif /* MICRO_BOOTER_H */

--- a/src/components/implementation/tests/unit_defcompinfo/unit_defcompinfo.c
+++ b/src/components/implementation/tests/unit_defcompinfo/unit_defcompinfo.c
@@ -56,7 +56,7 @@ test_aeps(void)
 		asndcap_t snd;
 
 		printc("\tCreating AEP [%d]\n", i);
-		ret = cos_aep_tcap_alloc(&(test_aep[i]), BOOT_CAPTBL_SELF_INITTCAP_BASE, aep_thd_fn, (void *)i);
+		ret = cos_aep_tcap_alloc(&(test_aep[i]), BOOT_CAPTBL_SELF_INITTCAP_BASE, aep_thd_fn, (void *)i, 0);
 		assert(ret == 0);
 
 		snd = cos_asnd_alloc(ci, test_aep[i].rcv, ci->captbl_cap);
@@ -125,7 +125,7 @@ cos_init(void)
 		cos_defcompinfo_init();
 
 		for (id = 0; id < CHILD_COMP_COUNT; id++) {
-			vaddr_t              vm_range, addr;
+			vaddr_t              vm_range, addr, scbaddr, dcbaddr;
 			pgtblcap_t           child_utpt;
 			int                  is_sched = ((id == CHILD_SCHED_ID) ? 1 : 0);
 			struct cos_compinfo *child_ci = cos_compinfo_get(&child_defci[id]);
@@ -136,7 +136,7 @@ cos_init(void)
 
 			cos_meminfo_init(&(child_ci->mi), BOOT_MEM_KM_BASE, CHILD_UNTYPED_SIZE, child_utpt);
 			cos_defcompinfo_child_alloc(&child_defci[id], (vaddr_t)&cos_upcall_entry,
-			                            (vaddr_t)BOOT_MEM_VM_BASE, BOOT_CAPTBL_FREE, is_sched);
+			                            (vaddr_t)BOOT_MEM_VM_BASE, BOOT_CAPTBL_FREE, is_sched, &dcbaddr, &scbaddr);
 
 			printc("\t\tCopying new capabilities\n");
 			ret = cos_cap_cpy_at(child_ci, BOOT_CAPTBL_SELF_CT, ci, child_ci->captbl_cap);

--- a/src/components/implementation/tests/unit_schedtests/Makefile
+++ b/src/components/implementation/tests/unit_schedtests/Makefile
@@ -2,7 +2,7 @@ COMPONENT=unit_schedlibtests.o
 INTERFACES=
 DEPENDENCIES=
 IF_LIB=
-ADDITIONAL_LIBS=-lcobj_format $(LIBSLRAW) -lsl_mod_fprr -lsl_thd_static_backend
+ADDITIONAL_LIBS=-lcobj_format $(LIBSLRAW) -lsl_mod_rr -lsl_thd_static_backend
 
 include ../../Makefile.subsubdir
 MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
+++ b/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
@@ -90,7 +90,7 @@ test_thd_fn(void *data)
 	while (1) {
 		int workiters = WORKITERS * ((int)data);
 
-		printc("%d", (int)data);
+		printc("%c", 'a' + (int)data);
 		//SPIN(workiters);
 		sl_thd_yield(0);
 	}

--- a/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
+++ b/src/components/implementation/tests/unit_schedtests/unit_schedlib.c
@@ -40,8 +40,6 @@ static volatile int testing = 1;
 void
 test_thd_perffn(void *data)
 {
-	struct cos_compinfo *ci = cos_compinfo_get(cos_defcompinfo_curr_get());
-	thdcap_t thdc = 0;
 	cycles_t start_cycs = 0, end_cycs = 0, wc_cycs = 0, total_cycs = 0;
 	unsigned int i = 0;
 
@@ -70,9 +68,6 @@ test_thd_perffn(void *data)
 	PRINTC("SWITCH UBENCH: avg: %llu, wc: %llu, iters:%u\n", (total_cycs / (2 * PERF_ITERS)), wc_cycs, PERF_ITERS);
 	testing = 0;
 	/* done testing! let the spinfn cleanup! */
-	PRINTC("CURR THD: %u\n", (unsigned int)cos_introspect(ci, ci->comp_cap, COMP_GET_SCB_CURTHD));
-	thdc = sl_thd_thdcap(sl_thd_curr());
-	PRINTC("%u DCB IP: %lx, DCB SP: %lx\n", (unsigned int)thdc, (unsigned long)cos_introspect(ci, thdc, THD_GET_DCB_IP), (unsigned long)cos_introspect(ci, thdc, THD_GET_DCB_SP));
 	sl_thd_yield(0);
 
 	sl_thd_exit();
@@ -81,17 +76,11 @@ test_thd_perffn(void *data)
 void
 test_thd_spinfn(void *data)
 {
-	struct cos_compinfo *ci = cos_compinfo_get(cos_defcompinfo_curr_get());
-	thdcap_t thdc = 0;
-
 	while (likely(testing)) {
 		rdtscll(mid_cycs);
 		sl_thd_yield(0);
 	}
 
-	thdc = sl_thd_thdcap(sl_thd_curr());
-	PRINTC("CURR THD: %u\n", (unsigned int)cos_introspect(ci, ci->comp_cap, COMP_GET_SCB_CURTHD));
-	PRINTC("%u DCB IP: %lx, DCB SP: %lx\n", (unsigned int)thdc, (unsigned long)cos_introspect(ci, thdc, THD_GET_DCB_IP), (unsigned long)cos_introspect(ci, thdc, THD_GET_DCB_SP));
 	sl_thd_exit();
 }
 
@@ -102,7 +91,7 @@ test_thd_fn(void *data)
 		int workiters = WORKITERS * ((int)data);
 
 		printc("%d", (int)data);
-		SPIN(workiters);
+		//SPIN(workiters);
 		sl_thd_yield(0);
 	}
 }
@@ -112,12 +101,7 @@ test_yield_perf(void)
 {
 	int                     i;
 	struct sl_thd          *threads[N_TESTTHDS_PERF];
-	struct cos_compinfo *ci = cos_compinfo_get(cos_defcompinfo_curr_get());
 	union sched_param_union sp = {.c = {.type = SCHEDP_PRIO, .value = 31}};
-	struct cos_scb_info *scb_info = cos_scb_info_get();
-
-	scb_info->curr_thd = BOOT_CAPTBL_SELF_INITTHD_CPU_BASE;
-	PRINTC("CURR THD: %u\n", (unsigned int)cos_introspect(ci, ci->comp_cap, COMP_GET_SCB_CURTHD));
 
 	for (i = 0; i < N_TESTTHDS_PERF; i++) {
 		if (i == 1) threads[i] = sl_thd_alloc(test_thd_perffn, (void *)&threads[0]);
@@ -125,7 +109,6 @@ test_yield_perf(void)
 		assert(threads[i]);
 		sl_thd_param_set(threads[i], sp.v);
 		PRINTC("Thread %u:%lu created\n", sl_thd_thdid(threads[i]), sl_thd_thdcap(threads[i]));
-		PRINTC("%u DCB IP: %lx, DCB SP: %lx\n", (unsigned int)sl_thd_thdcap(threads[i]), (unsigned long)cos_introspect(ci, sl_thd_thdcap(threads[i]), THD_GET_DCB_IP), (unsigned long)cos_introspect(ci, sl_thd_thdcap(threads[i]), THD_GET_DCB_SP));
 	}
 }
 
@@ -238,8 +221,8 @@ cos_init(void)
 	cos_defcompinfo_init();
 	sl_init(SL_MIN_PERIOD_US);
 
-	test_yield_perf();
-	//test_yields();
+	//test_yield_perf();
+	test_yields();
 	//test_blocking_directed_yield();
 	//test_timeout_wakeup();
 

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -220,6 +220,12 @@ cos_scb_info_get(void)
 	return scb_info;
 }
 
+static inline struct cos_scb_info *
+cos_scb_info_get_core(void)
+{
+	return cos_scb_info_get() + cos_cpuid();
+}
+
 static inline struct cos_dcb_info *
 cos_init_dcb_get(void)
 {

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -203,12 +203,36 @@ cos_spd_id(void)
 static inline void *
 cos_get_heap_ptr(void)
 {
-	return (void *)cos_comp_info.cos_heap_ptr;
+	/* page at heap_ptr is actually the SCB_PAGE for the booter alone! */
+	unsigned int off = (cos_spd_id() == 0 ? (COS_SCB_SIZE + (PAGE_SIZE * NUM_CPU)) : 0);
+	void *heap_ptr = ((void *)(cos_comp_info.cos_heap_ptr + off));
+
+	return heap_ptr;
+}
+
+static inline struct cos_scb_info *
+cos_scb_info_get(void)
+{
+	struct cos_scb_info *scb_info = cos_comp_info.cos_scb_data;
+
+	if (cos_spd_id() == 0) scb_info = (struct cos_scb_info *)(cos_comp_info.cos_heap_ptr);
+
+	return scb_info;
+}
+
+static inline struct cos_dcb_info *
+cos_init_dcb_get(void)
+{
+	/* created at boot-time for the first component in the system! */
+	if (cos_spd_id() == 0) return (struct cos_dcb_info *)(cos_comp_info.cos_heap_ptr + COS_SCB_SIZE + (PAGE_SIZE * cos_cpuid()));
+
+	return NULL;
 }
 
 static inline void
 cos_set_heap_ptr(void *addr)
 {
+	/* FIXME: fix this for the hack if it's not going to work! */
 	cos_comp_info.cos_heap_ptr = (vaddr_t)addr;
 }
 

--- a/src/components/include/cos_dcb.h
+++ b/src/components/include/cos_dcb.h
@@ -1,0 +1,11 @@
+#ifndef COS_DCB_H
+#define COS_DCB_H
+
+#include <cos_types.h>
+
+#define COS_DCB_PERPG_MAX (PAGE_SIZE / sizeof(struct cos_dcb_info))
+
+void cos_dcb_info_init(void);
+struct cos_dcb_info *cos_dcb_info_assign(void);
+
+#endif /* COS_DCB_H */

--- a/src/components/include/cos_defkernel_api.h
+++ b/src/components/include/cos_defkernel_api.h
@@ -36,7 +36,7 @@ struct cos_aep_info {
 	thdid_t         tid;
 	arcvcap_t       rcv;
 	cos_aepthd_fn_t fn;
-	void *          data;
+	void           *data;
 };
 
 /* Default Component information */
@@ -53,7 +53,7 @@ cos_aepthd_fn(void *data)
 {
 	struct cos_aep_info *aep_info = (struct cos_aep_info *)data;
 	cos_aepthd_fn_t      aep_fn   = aep_info->fn;
-	void *               fn_data  = aep_info->data;
+	void                *fn_data  = aep_info->data;
 
 	(aep_fn)(aep_info->rcv, fn_data);
 
@@ -96,44 +96,49 @@ void cos_defcompinfo_sched_init(void);
  * cos_defcompinfo_child_alloc: called to create a new child component including initial capabilities like pgtbl,
  * captbl, compcap, aep. if is_sched is set, scheduling end-point will also be created for the child component, else,
  * the current component's scheduler will remain the scheduler for the child component.
+ * NOTE: dcbuaddr is the address in child_dci page-table and scbuaddr too!.
  */
 int cos_defcompinfo_child_alloc(struct cos_defcompinfo *child_defci, vaddr_t entry, vaddr_t heap_ptr,
-                                capid_t cap_frontier, int is_sched);
+                                capid_t cap_frontier, int is_sched, vaddr_t *dcbuaddr, vaddr_t *scbuaddr);
 
 /*
  * cos_aep_alloc: creates a new async activation end-point which includes thread, tcap and rcv capabilities.
  *                struct cos_aep_info passed in, must not be stack allocated.
  */
-int cos_aep_alloc(struct cos_aep_info *aep, cos_aepthd_fn_t fn, void *data);
+int cos_aep_alloc(struct cos_aep_info *aep, cos_aepthd_fn_t fn, void *data, vaddr_t dcbuaddr);
 /*
  * cos_aep_alloc: creates a new async activation end-point, using an existing tcap.
  *                struct cos_aep_info passed in, must not be stack allocated.
  */
-int cos_aep_tcap_alloc(struct cos_aep_info *aep, tcap_t tc, cos_aepthd_fn_t fn, void *data);
+int cos_aep_tcap_alloc(struct cos_aep_info *aep, tcap_t tc, cos_aepthd_fn_t fn, void *data, vaddr_t dcbuaddr);
 
 /*
  * cos_initaep_alloc: create an initaep in the @child_dci and using sched->rcv as the parent, sets up cos_sched_ape_get(@child_dci) with the init capabilities.
  * 		      if @sched == NULL, use the current scheduler in cos_sched_aep_get(cos_defcompinfo_get_cur()).
  *                    if @is_sched == 0, creates only the init thread (does not need @sched parameter)
+ * NOTE: dcbuaddr is the address in child_dci page-table.
  */
-int cos_initaep_alloc(struct cos_defcompinfo *child_dci, struct cos_aep_info *sched, int is_sched);
+int cos_initaep_alloc(struct cos_defcompinfo *child_dci, struct cos_aep_info *sched, int is_sched, vaddr_t dcbuaddr);
 /*
  * cos_initaep_tcap_alloc: same as cos_initaep_alloc with is_sched == 1, except it doesn't create a new tcap,
  *			   uses the tcap passed in @tc.
+ * NOTE: dcbuaddr is the address in child_dci page-table.
  */
-int cos_initaep_tcap_alloc(struct cos_defcompinfo *child_dci, tcap_t tc, struct cos_aep_info *sched);
+int cos_initaep_tcap_alloc(struct cos_defcompinfo *child_dci, tcap_t tc, struct cos_aep_info *sched, vaddr_t dcbuaddr);
 
 /*
  * cos_aep_alloc_ext: creates a new async activation end-point which includes thread, tcap and rcv capabilities in the child_dci component using sched_aep->rcv.
  *		      if @child_dci == NULL, create in the current component.
+ * NOTE: dcbuaddr is the address in child_dci page-table.
  */
-int cos_aep_alloc_ext(struct cos_aep_info *aep, struct cos_defcompinfo *child_dci, struct cos_aep_info *sched_aep, thdclosure_index_t idx);
+int cos_aep_alloc_ext(struct cos_aep_info *aep, struct cos_defcompinfo *child_dci, struct cos_aep_info *sched_aep, thdclosure_index_t idx, vaddr_t dcbuaddr);
 
 /*
  * cos_aep_alloc_ext: creates a new async activation end-point which includes thread, tcap and rcv capabilities in the child_dci component using sched_aep->rcv.
  *		      if @child_dci == NULL, create in the current component.
+ * NOTE: dcbuaddr is the address in child_dci page-table.
  */
-int cos_aep_tcap_alloc_ext(struct cos_aep_info *aep, struct cos_defcompinfo *child_dci, struct cos_aep_info *sched_aep, tcap_t tc, thdclosure_index_t idx);
+int cos_aep_tcap_alloc_ext(struct cos_aep_info *aep, struct cos_defcompinfo *child_dci, struct cos_aep_info *sched_aep, tcap_t tc, thdclosure_index_t idx, vaddr_t dcbuaddr);
 
 /*
  * cos_defswitch: thread switch api using the default scheduling tcap and rcv.

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -108,22 +108,25 @@ int cos_pgtbl_intern_expandwith(struct cos_compinfo *ci, pgtblcap_t intern, vadd
  * correctly populate ci (allocating all resources from ci_resources).
  */
 int         cos_compinfo_alloc(struct cos_compinfo *ci, vaddr_t heap_ptr, capid_t cap_frontier, vaddr_t entry,
-                               struct cos_compinfo *ci_resources);
+                               struct cos_compinfo *ci_resources, vaddr_t *scbpg);
 captblcap_t cos_captbl_alloc(struct cos_compinfo *ci);
 pgtblcap_t  cos_pgtbl_alloc(struct cos_compinfo *ci);
-compcap_t   cos_comp_alloc(struct cos_compinfo *ci, captblcap_t ctc, pgtblcap_t ptc, vaddr_t entry);
+compcap_t   cos_comp_alloc(struct cos_compinfo *ci, captblcap_t ctc, pgtblcap_t ptc, vaddr_t entry, vaddr_t scbpg);
 
 typedef void (*cos_thd_fn_t)(void *);
-thdcap_t cos_thd_alloc(struct cos_compinfo *ci, compcap_t comp, cos_thd_fn_t fn, void *data);
-thdcap_t cos_thd_alloc_ext(struct cos_compinfo *ci, compcap_t comp, thdclosure_index_t idx);
+thdcap_t cos_thd_alloc(struct cos_compinfo *ci, compcap_t comp, cos_thd_fn_t fn, void *data, pgtblcap_t ptc, vaddr_t dcbuaddr);
+thdcap_t cos_thd_alloc_ext(struct cos_compinfo *ci, compcap_t comp, thdclosure_index_t idx, pgtblcap_t ptc, vaddr_t dcbuaddr);
 /* Create the initial (cos_init) thread */
-thdcap_t  cos_initthd_alloc(struct cos_compinfo *ci, compcap_t comp);
+thdcap_t  cos_initthd_alloc(struct cos_compinfo *ci, compcap_t comp, pgtblcap_t, vaddr_t dcbuaddr);
 sinvcap_t cos_sinv_alloc(struct cos_compinfo *srcci, compcap_t dstcomp, vaddr_t entry, invtoken_t token);
 arcvcap_t cos_arcv_alloc(struct cos_compinfo *ci, thdcap_t thdcap, tcap_t tcapcap, compcap_t compcap, arcvcap_t enotif);
 asndcap_t cos_asnd_alloc(struct cos_compinfo *ci, arcvcap_t arcvcap, captblcap_t ctcap);
 
 void *cos_page_bump_alloc(struct cos_compinfo *ci);
 void *cos_page_bump_allocn(struct cos_compinfo *ci, size_t sz);
+
+void *cos_dcbpg_bump_allocn(struct cos_compinfo *ci, size_t sz);
+void *cos_scbpg_bump_allocn(struct cos_compinfo *ci, size_t sz);
 
 capid_t cos_cap_cpy(struct cos_compinfo *dstci, struct cos_compinfo *srcci, cap_t srcctype, capid_t srccap);
 int     cos_cap_cpy_at(struct cos_compinfo *dstci, capid_t dstcap, struct cos_compinfo *srcci, capid_t srccap);

--- a/src/components/include/res_spec.h
+++ b/src/components/include/res_spec.h
@@ -64,10 +64,10 @@ sched_param_pack(sched_param_type_t type, unsigned int value)
 static inline void
 sched_param_get(sched_param_t sp, sched_param_type_t *type, unsigned int *value)
 {
-	struct sched_param_s s = *(struct sched_param_s *)(void *)&sp;
+	union sched_param_union us = *(union sched_param_union *)&sp;
 
-	*type  = s.type;
-	*value = s.value;
+	*type  = us.c.type;
+	*value = us.c.value;
 }
 
 #endif /* RES_SPEC_H */

--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -411,17 +411,15 @@ sl_thd_dispatch(struct sl_thd *next, sched_tok_t tok, struct sl_thd *curr)
 {
 	struct cos_scb_info *scb = sl_scb_info_cpu();
 
-	/* TODO: remove 3f label and use dcb->ip + OFFSET for kernel jump */
 	/* TODO: token check outside the assembly */
 
 	__asm__ __volatile__ (				\
 		"movl $2f, (%%eax)\n\t"			\
-		"movl $3f, 4(%%eax)\n\t"		\
-		"movl %%esp, 8(%%eax)\n\t"		\
-		"cmp $0, 8(%%ebx)\n\t"			\
+		"movl %%esp, 4(%%eax)\n\t"		\
+		"cmp $0, 4(%%ebx)\n\t"			\
 		"je 1f\n\t"				\
 		"movl %%edx, (%%ecx)\n\t"		\
-		"movl 8(%%ebx), %%esp\n\t"		\
+		"movl 4(%%ebx), %%esp\n\t"		\
 		"jmp *(%%ebx)\n\t"			\
 		"1:\n\t"				\
 		"pushl %%ebp\n\t"			\
@@ -431,8 +429,10 @@ sl_thd_dispatch(struct sl_thd *next, sched_tok_t tok, struct sl_thd *curr)
 		"addl $4, %%esp\n\t"			\
 		"popl %%ebp\n\t"			\
 		"jmp 3f\n\t"				\
+		".align 4\n\t"				\
 		"2:\n\t"				\
-		"movl $0, 8(%%ebx)\n\t"			\
+		"movl $0, 4(%%ebx)\n\t"			\
+		".align 4\n\t"				\
 		"3:\n\t"				\
 		:
 		: "a" (sl_thd_dcbinfo(curr)), "b" (sl_thd_dcbinfo(next)),

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -33,11 +33,6 @@ struct event_info {
 	tcap_time_t timeout;
 };
 
-struct sl_dcb_info {
-	unsigned long ip;
-	unsigned long sp;
-} __attribute__((__packed__));
-
 struct sl_thd {
 	sl_thd_state_t       state;
 	/*
@@ -101,20 +96,20 @@ struct sl_thd {
 	struct event_info event_info;
 	struct ps_list    SL_THD_EVENT_LIST; /* list of events for the scheduler end-point */
 
-	struct sl_dcb_info dcb;
+	struct cos_dcb_info *dcb;
 };
 
-static inline struct sl_dcb_info *
+static inline struct cos_dcb_info *
 sl_thd_dcbinfo(struct sl_thd *t)
-{ return &t->dcb; }
+{ return t->dcb; }
 
 static inline unsigned long *
 sl_thd_ip(struct sl_thd *t)
-{ return &t->dcb.ip; }
+{ return &t->dcb->ip; }
 
 static inline unsigned long *
 sl_thd_sp(struct sl_thd *t)
-{ return &t->dcb.sp; }
+{ return &t->dcb->sp; }
 
 static inline struct cos_aep_info *
 sl_thd_aepinfo(struct sl_thd *t)

--- a/src/components/include/sl_thd.h
+++ b/src/components/include/sl_thd.h
@@ -33,6 +33,11 @@ struct event_info {
 	tcap_time_t timeout;
 };
 
+struct sl_dcb_info {
+	unsigned long ip;
+	unsigned long sp;
+} __attribute__((__packed__));
+
 struct sl_thd {
 	sl_thd_state_t       state;
 	/*
@@ -95,7 +100,21 @@ struct sl_thd {
 
 	struct event_info event_info;
 	struct ps_list    SL_THD_EVENT_LIST; /* list of events for the scheduler end-point */
+
+	struct sl_dcb_info dcb;
 };
+
+static inline struct sl_dcb_info *
+sl_thd_dcbinfo(struct sl_thd *t)
+{ return &t->dcb; }
+
+static inline unsigned long *
+sl_thd_ip(struct sl_thd *t)
+{ return &t->dcb.ip; }
+
+static inline unsigned long *
+sl_thd_sp(struct sl_thd *t)
+{ return &t->dcb.sp; }
 
 static inline struct cos_aep_info *
 sl_thd_aepinfo(struct sl_thd *t)

--- a/src/components/include/sl_xcpu.h
+++ b/src/components/include/sl_xcpu.h
@@ -64,6 +64,7 @@ struct sl_global {
 	struct sl_xcpu_request xcpu_rbuf[NUM_CPU][SL_XCPU_RING_SIZE];
 	u32_t cpu_bmp[(NUM_CPU + 7)/8]; /* bitmap of cpus this scheduler is running on! */
 	asndcap_t xcpu_asnd[NUM_CPU][NUM_CPU];
+	struct cos_scb_info *scb_area;
 } CACHE_ALIGNED;
 
 extern struct sl_global sl_global_data;

--- a/src/components/interface/capmgr/memmgr.h
+++ b/src/components/interface/capmgr/memmgr.h
@@ -11,4 +11,7 @@ cbuf_t        memmgr_shared_page_alloc(vaddr_t *pgaddr);
 cbuf_t        memmgr_shared_page_allocn(unsigned long num_pages, vaddr_t *pgaddr);
 unsigned long memmgr_shared_page_map(cbuf_t id, vaddr_t *pgaddr);
 
+vaddr_t memmgr_initdcbpage_retrieve(void);
+vaddr_t memmgr_dcbpage_allocn(unsigned long num_pages);
+
 #endif /* MEMMGR_H */

--- a/src/components/interface/capmgr/stubs/s_stub.S
+++ b/src/components/interface/capmgr/stubs/s_stub.S
@@ -14,5 +14,7 @@ cos_asm_server_stub(capmgr_asnd_rcv_create)
 cos_asm_server_stub(capmgr_asnd_key_create)
 
 cos_asm_server_stub(memmgr_heap_page_allocn)
+cos_asm_server_stub(memmgr_initdcbpage_retrieve)
+cos_asm_server_stub(memmgr_dcbpage_allocn)
 cos_asm_server_stub_rets(memmgr_shared_page_allocn_cserialized)
 cos_asm_server_stub_rets(memmgr_shared_page_map_cserialized)

--- a/src/components/lib/Makefile
+++ b/src/components/lib/Makefile
@@ -1,6 +1,6 @@
 include Makefile.src Makefile.comp
 
-LIB_OBJS=heap.o cobj_format.o cos_kernel_api.o cos_defkernel_api.o
+LIB_OBJS=heap.o cobj_format.o cos_kernel_api.o cos_defkernel_api.o cos_dcbraw.o cos_dcbcapmgr.o
 LIBS=$(LIB_OBJS:%.o=%.a)
 MANDITORY=c_stub.o cos_asm_upcall.o cos_asm_ainv.o cos_component.o
 MAND=$(MANDITORY_LIB)

--- a/src/components/lib/cos_component.c
+++ b/src/components/lib/cos_component.c
@@ -191,13 +191,17 @@ cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
 					cos_thd_entry_exec(idx);
 				}
 			}
-			return;
+			break;
 		}
 	default:
 		/* fault! */
 		assert(0);
 		return;
 	}
+
+	/* FIXME: for now, don't let threads page-fault on return! */
+	while (1) ;
+
 	return;
 }
 

--- a/src/components/lib/cos_dcbcapmgr.c
+++ b/src/components/lib/cos_dcbcapmgr.c
@@ -1,0 +1,45 @@
+#include <cos_dcb.h>
+#include <cos_kernel_api.h>
+#include <../interface/capmgr/memmgr.h>
+
+static unsigned long free_off[NUM_CPU] CACHE_ALIGNED = { 0 };
+static struct cos_dcb_info *dcb_off[NUM_CPU] CACHE_ALIGNED = { NULL }, *initdcb[NUM_CPU] CACHE_ALIGNED = { NULL };
+
+void
+cos_dcb_info_init(void)
+{
+	dcb_off[cos_cpuid()] = initdcb[cos_cpuid()] = (struct cos_dcb_info *)memmgr_initdcbpage_retrieve();
+	assert(initdcb[cos_cpuid()]);
+
+	dcb_off[cos_cpuid()]++;
+	free_off[cos_cpuid()] = 1;
+}
+
+void
+cos_dcb_info_alloc(void)
+{
+	dcb_off[cos_cpuid()] = (struct cos_dcb_info *)memmgr_dcbpage_allocn(1);
+	assert(dcb_off[cos_cpuid()]);
+
+	free_off[cos_cpuid()] = 0;
+}
+
+struct cos_dcb_info *
+cos_dcb_info_assign(void)
+{
+	unsigned long curr_off = 0;
+
+	curr_off = ps_faa(&free_off[cos_cpuid()], 1);
+	if (curr_off >= COS_DCB_PERPG_MAX) {
+		cos_dcb_info_alloc();
+		curr_off = ps_faa(&free_off[cos_cpuid()], 1);
+	}
+
+	return (dcb_off[cos_cpuid()] + curr_off);
+}
+
+struct cos_dcb_info *
+cos_dcb_info_init_get(void)
+{
+	return initdcb[cos_cpuid()];
+}

--- a/src/components/lib/cos_dcbraw.c
+++ b/src/components/lib/cos_dcbraw.c
@@ -1,0 +1,47 @@
+#include <cos_dcb.h>
+#include <cos_kernel_api.h>
+#include <cos_defkernel_api.h>
+
+static unsigned long free_off[NUM_CPU] CACHE_ALIGNED = { 0 };
+static struct cos_dcb_info *dcb_off[NUM_CPU] CACHE_ALIGNED = { NULL }, *initdcb[NUM_CPU] CACHE_ALIGNED = { NULL };
+
+void
+cos_dcb_info_init(void)
+{
+	dcb_off[cos_cpuid()] = initdcb[cos_cpuid()] = cos_init_dcb_get();
+	assert(initdcb[cos_cpuid()]);
+
+	dcb_off[cos_cpuid()]++;
+	free_off[cos_cpuid()] = 1;
+}
+
+void
+cos_dcb_info_alloc(void)
+{
+	struct cos_compinfo *ci_res = cos_compinfo_get(cos_defcompinfo_curr_get());
+
+	dcb_off[cos_cpuid()] = cos_dcbpg_bump_allocn(ci_res, PAGE_SIZE);
+	assert(dcb_off[cos_cpuid()]);
+
+	free_off[cos_cpuid()] = 0;
+}
+
+struct cos_dcb_info *
+cos_dcb_info_assign(void)
+{
+	unsigned long curr_off = 0;
+
+	curr_off = ps_faa(&free_off[cos_cpuid()], 1);
+	if (curr_off >= COS_DCB_PERPG_MAX) {
+		cos_dcb_info_alloc();
+		curr_off = ps_faa(&free_off[cos_cpuid()], 1);
+	}
+
+	return (dcb_off[cos_cpuid()] + curr_off);
+}
+
+struct cos_dcb_info *
+cos_dcb_info_init_get(void)
+{
+	return initdcb[cos_cpuid()];
+}

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -860,9 +860,7 @@ cos_thd_wakeup(thdcap_t thd, tcap_t tc, tcap_prio_t prio, tcap_res_t res)
 sched_tok_t
 cos_sched_sync(void)
 {
-	static sched_tok_t stok[NUM_CPU] CACHE_ALIGNED;
-
-	return ps_faa((unsigned long *)&stok[cos_cpuid()], 1);
+	return ps_load(&cos_scb_info_get_core()->sched_tok);
 }
 
 int

--- a/src/components/lib/posix/posix.c
+++ b/src/components/lib/posix/posix.c
@@ -362,7 +362,7 @@ struct sl_lock futex_lock = SL_LOCK_STATIC_INIT();
 int
 cos_futex_wait(struct futex_data *futex, int *uaddr, int val, const struct timespec *timeout)
 {
-	cycles_t   deadline;
+	cycles_t   deadline = sl_now();
 	microsec_t wait_time;
 	struct futex_waiter waiter = (struct futex_waiter) {
 		.thdid = sl_thdid()

--- a/src/components/lib/sl/Makefile
+++ b/src/components/lib/sl/Makefile
@@ -1,6 +1,6 @@
 include Makefile.src Makefile.comp
 
-LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_fprr.o sl_lock.o sl_thd_static_backend.o
+LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_rr.o sl_mod_fprr.o sl_lock.o sl_thd_static_backend.o
 LIBS=$(LIB_OBJS:%.o=%.a)
 CINC+=-m32
 

--- a/src/components/lib/sl/Makefile
+++ b/src/components/lib/sl/Makefile
@@ -1,6 +1,6 @@
 include Makefile.src Makefile.comp
 
-LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_rr.o sl_mod_fprr.o sl_lock.o sl_thd_static_backend.o
+LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_fprr.o sl_mod_rr.o sl_lock.o sl_thd_static_backend.o sl_slowpath.o
 LIBS=$(LIB_OBJS:%.o=%.a)
 CINC+=-m32
 
@@ -11,6 +11,11 @@ all: $(LIBS)
 %.a:%.c
 	$(info |     [CC]   Creating library file $@ from $^)
 	@$(CC) $(CFLAGS) $(CINC) -o $(@:%.a=%.o) -c $<
+	@$(AR) cr lib$@ $(@:%.a=%.o)
+
+%.a:%.S
+	$(info |     [AS] Creating library file $@ from $^)
+	@$(AS) $(ASFLAGS) -c -o $(@:%.a=%.o) $^
 	@$(AR) cr lib$@ $(@:%.a=%.o)
 
 clean:

--- a/src/components/lib/sl/Makefile
+++ b/src/components/lib/sl/Makefile
@@ -1,6 +1,6 @@
 include Makefile.src Makefile.comp
 
-LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_fprr.o sl_mod_rr.o sl_lock.o sl_thd_static_backend.o sl_slowpath.o
+LIB_OBJS=sl_capmgr.o sl_raw.o sl_sched.o sl_xcpu.o sl_child.o sl_mod_fprr.o sl_mod_rr.o sl_lock.o sl_thd_static_backend.o
 LIBS=$(LIB_OBJS:%.o=%.a)
 CINC+=-m32
 

--- a/src/components/lib/sl/sl_mod_rr.c
+++ b/src/components/lib/sl/sl_mod_rr.c
@@ -1,0 +1,98 @@
+#include <sl.h>
+#include <sl_consts.h>
+#include <sl_mod_policy.h>
+#include <sl_plugins.h>
+
+#define SL_FPRR_PERIOD_US_MIN  SL_MIN_PERIOD_US
+
+struct ps_list_head threads[NUM_CPU] CACHE_ALIGNED;
+
+/* No RR yet */
+void
+sl_mod_execution(struct sl_thd_policy *t, cycles_t cycles)
+{ }
+
+struct sl_thd_policy *
+sl_mod_schedule(void)
+{
+	struct sl_thd_policy *t = NULL;
+
+	if (ps_list_head_empty(&threads[cos_cpuid()])) goto done;
+	t = ps_list_head_first_d(&threads[cos_cpuid()], struct sl_thd_policy);
+	ps_list_rem_d(t);
+	ps_list_head_append_d(&threads[cos_cpuid()], t);
+
+done:
+	return t;
+}
+
+void
+sl_mod_block(struct sl_thd_policy *t)
+{
+	ps_list_rem_d(t);
+}
+
+void
+sl_mod_wakeup(struct sl_thd_policy *t)
+{
+	assert(ps_list_singleton_d(t));
+
+	ps_list_head_append_d(&threads[cos_cpuid()], t);
+}
+
+void
+sl_mod_yield(struct sl_thd_policy *t, struct sl_thd_policy *yield_to)
+{
+	ps_list_rem_d(t);
+	ps_list_head_append_d(&threads[cos_cpuid()], t);
+}
+
+void
+sl_mod_thd_create(struct sl_thd_policy *t)
+{
+	t->priority    = TCAP_PRIO_MIN;
+	t->period      = 0;
+	t->period_usec = 0;
+	ps_list_init_d(t);
+}
+
+void
+sl_mod_thd_delete(struct sl_thd_policy *t)
+{ ps_list_rem_d(t); }
+
+void
+sl_mod_thd_param_set(struct sl_thd_policy *t, sched_param_type_t type, unsigned int v)
+{
+	int cpu = cos_cpuid();
+
+	switch (type) {
+	case SCHEDP_PRIO:
+	{
+		t->priority = v;
+		sl_thd_setprio(sl_mod_thd_get(t), t->priority);
+		ps_list_head_append_d(&threads[cos_cpuid()], t);
+
+		break;
+	}
+	case SCHEDP_WINDOW:
+	{
+		assert(v >= SL_FPRR_PERIOD_US_MIN);
+		t->period_usec    = v;
+		t->period         = sl_usec2cyc(v);
+		/* FIXME: synchronize periods for all tasks */
+
+		break;
+	}
+	case SCHEDP_BUDGET:
+	{
+		break;
+	}
+	default: assert(0);
+	}
+}
+
+void
+sl_mod_init(void)
+{
+	ps_list_head_init(&threads[cos_cpuid()]);
+}

--- a/src/components/lib/sl/sl_sched.c
+++ b/src/components/lib/sl/sl_sched.c
@@ -190,6 +190,15 @@ update:
 	return 0;
 }
 
+int
+sl_thd_dispatch_slowpath(struct sl_thd *t, sched_tok_t tok)
+{
+	struct sl_global_cpu *g = sl__globals_cpu();
+
+	/* no timeouts for now! */
+	return cos_switch(sl_thd_thdcap(t), g->sched_tcap, t->prio, TCAP_TIME_NIL /*t == g->sched_thd ? TCAP_TIME_NIL : g->timeout_next*/, 0 /* don't switch to scheduler in the middle of this! */, tok);
+}
+
 /*
  * Wake "t" up if it was previously blocked on cos_rcv and got
  * to run before the scheduler (tcap-activated)!

--- a/src/components/lib/sl/sl_slowpath.S
+++ b/src/components/lib/sl/sl_slowpath.S
@@ -1,0 +1,9 @@
+.text
+.globl thd_dispatch_slowpath
+.type thd_dispatch_slowpath, @function
+thd_dispatch_slowpath:
+	pushl %edi
+	pushl %esi
+	call sl_thd_dispatch_slowpath
+	popl %esi
+	popl %edi

--- a/src/components/lib/sl/sl_slowpath.S
+++ b/src/components/lib/sl/sl_slowpath.S
@@ -1,9 +1,0 @@
-.text
-.globl thd_dispatch_slowpath
-.type thd_dispatch_slowpath, @function
-thd_dispatch_slowpath:
-	pushl %edi
-	pushl %esi
-	call sl_thd_dispatch_slowpath
-	popl %esi
-	popl %edi

--- a/src/kernel/include/pgtbl.h
+++ b/src/kernel/include/pgtbl.h
@@ -290,6 +290,7 @@ pgtbl_mapping_add(pgtbl_t pt, u32_t addr, u32_t page, u32_t flags)
 	                                          PGTBL_DEPTH, &accum);
 	if (!pte) return -ENOENT;
 	orig_v = (u32_t)(pte->next);
+//	printk("%p %x\n", pte, orig_v);
 
 	if (orig_v & PGTBL_PRESENT) return -EEXIST;
 	if (orig_v & PGTBL_COSFRAME) return -EPERM;
@@ -357,6 +358,7 @@ pgtbl_cosframe_add(pgtbl_t pt, u32_t addr, u32_t page, u32_t flags)
                                                   PGTBL_DEPTH, &accum);
 	orig_v = (u32_t)(pte->next);
 	assert(orig_v == 0);
+//	printk("%x %x %p %x\n", addr, page, pte, orig_v);
 
 	return __pgtbl_update_leaf(pte, (void *)(page | flags), 0);
 }

--- a/src/kernel/include/shared/cos_config.h
+++ b/src/kernel/include/shared/cos_config.h
@@ -60,6 +60,7 @@
 
 /* Composite user memory uses physical memory above this. */
 #define COS_MEM_START COS_MEM_KERN_PA
+#define COS_SCB_SIZE  (PAGE_SIZE)
 
 /* NUM_CPU_SOCKETS defined in cpu_ghz.h. The information is used for
  * intelligent IPI distribution. */

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -405,7 +405,7 @@ struct cos_scb_info {
 } CACHE_ALIGNED;
 
 struct cos_dcb_info {
-	unsigned long ip;
+	unsigned long ip, ip_kret;
 	unsigned long sp;
 } __attribute__((packed));
 

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -405,9 +405,24 @@ struct cos_scb_info {
 } CACHE_ALIGNED;
 
 struct cos_dcb_info {
-	unsigned long ip, ip_kret;
+	unsigned long ip;
 	unsigned long sp;
 } __attribute__((packed));
+
+/*
+ * This is the "ip" the kernel uses to update the thread when it sees that the
+ * thread is still in user-level dispatch routine.
+ * This is the offset of instruction after resetting the "next" thread's "sp" to zero
+ * in a purely user-level dispatch.
+ *
+ * Whenever kernel is switching to a thread which has "sp" non-zero, it would switch
+ * to the "ip" saved in the dcb_info and reset the "sp" of the thread that the kernel
+ * is dispatching to!
+ * This is necessary because, if the kernel is dispatching to a thread that was in the
+ * user-level dispatch routine before, then the only registers that it can restore are
+ * "ip" and "sp", everything else is either clobbered or saved/loaded at user-level.
+ */
+#define DCB_IP_KERN_OFF 8
 
 struct cos_component_information {
 	struct cos_stack_freelists cos_stacks;

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -291,12 +291,20 @@ enum
 {
 	/* thread id */
 	THD_GET_TID,
+	THD_GET_DCB_IP,
+	THD_GET_DCB_SP,
 };
 
 enum
 {
 	/* tcap budget */
 	TCAP_GET_BUDGET,
+};
+
+enum
+{
+	/* get current thread info from scb */
+	COMP_GET_SCB_CURTHD,
 };
 
 /* Macro used to define per core variables */
@@ -390,6 +398,16 @@ struct cos_stack_freelists {
 /* #error "Assembly in <fill in file name here> requires that COMP_INFO_STACK_FREELISTS != 1 ||
  * COMP_INFO_TMEM_STK_RELINQ != 0.  Change the defines, or change the assembly" */
 /* #endif */
+struct cos_scb_info {
+	capid_t     curr_thd;
+	cycles_t    timer_next;
+	sched_tok_t sched_tok;
+} CACHE_ALIGNED;
+
+struct cos_dcb_info {
+	unsigned long ip;
+	unsigned long sp;
+} __attribute__((packed));
 
 struct cos_component_information {
 	struct cos_stack_freelists cos_stacks;
@@ -400,7 +418,7 @@ struct cos_component_information {
 	vaddr_t                    cos_heap_allocated, cos_heap_alloc_extent;
 	vaddr_t                    cos_upcall_entry;
 	vaddr_t                    cos_async_inv_entry;
-	//	struct cos_sched_data_area *cos_sched_data_area;
+	struct cos_scb_info               *cos_scb_data;
 	vaddr_t                            cos_user_caps;
 	struct restartable_atomic_sequence cos_ras[COS_NUM_ATOMIC_SECTIONS / 2];
 	vaddr_t                            cos_poly[COMP_INFO_POLY_NUM];

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -590,10 +590,10 @@ thd_switch_update(struct thread *thd, struct pt_regs *regs, int issame)
 
 	if (thd->dcbinfo && thd->dcbinfo->sp) {
 		if (!preempt) {
-			regs->dx = regs->ip = thd->dcbinfo->ip_kret;
+			regs->dx = regs->ip = thd->dcbinfo->ip + DCB_IP_KERN_OFF;
 			regs->cx = regs->sp = thd->dcbinfo->sp;
 		} else {
-			regs->ip = thd->dcbinfo->ip_kret;
+			regs->ip = thd->dcbinfo->ip + DCB_IP_KERN_OFF;
 			regs->sp = thd->dcbinfo->sp;
 		}
 		thd->dcbinfo->sp = 0;

--- a/src/platform/i386/qemu-kvm.sh
+++ b/src/platform/i386/qemu-kvm.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+if [ $# != 1 ]; then
+  echo "Usage: $0 <run-script.sh>"
+  exit 1
+fi
+
+if ! [ -r $1 ]; then
+  echo "Can't open run-script"
+  exit 1
+fi
+
+MODULES=$(sh $1 | awk '/^Writing image/ { print $3; }' | tr '\n' ' ')
+
+#qemu-system-i386 -m 768 -nographic -kernel kernel.img -no-reboot -s -initrd "$(echo $MODULES | tr ' ' ',')"
+qemu-system-i386 -enable-kvm -rtc base=localtime,clock=host,driftfix=none -smp sockets=1,cores=1,threads=1 -cpu host -nographic -m 768 -kernel kernel.img -initrd "$(echo $MODULES | tr ' ' ',')"


### PR DESCRIPTION
### Summary of this Pull Request (PR)

This PR adds user-level thread dispatch feature.

@hungry-foolish some pointers for code changes in this PR:
* Look at llbooter (boot_deps.h) for SCB page setup for each component and initial DCB page setup for root-scheduler.
* Look at platform/i386/boot_comp.c for SCB and INIT DCB page setup for the root-component.
* Look into sl.h for user-level dispatch routine (in assembly).
* Look into cos_kernel_api.c for SCB page and component allocation api changes. Also for DCB page allocation api. (This will change soon.)
* Look into cos_kernel_api.c for changes to thread allocation api to pass in the address of DCB entry.
* Look into cos_kernel_api, sl, capmgr for other changes that enable the rest of the system use SCB/DCB/user-level dispatch functionality.

**TODO:**
* SCB and DCB capability abstraction (next thing that I'll be working on!)
* Code optimization in kernel fast-path code section for restoring thread consistency.
* SL optimization to bring down the cycles in "schedule()" like function to about ~30-50cycles. sl_thd_yield() as of now is about 280 cycles with just RR (compared to 670 cycles with just kernel switches and using FPRR).
* more..

**NOTE:** 
* This branch is based on smp-ioapic stuff which is beyond ppos (with IOAPIC stuff) too. 

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@hungry-foolish @gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [x] micro_booter
- [ ] unit_pingpong
- [x] unit_schedtests
- [ ] ...(add others here)
