### PR TITLE
Makefile: Use a more generic way to fetch CPU speed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -48,7 +48,7 @@ config-gen: update
 	@echo "Configuring the system with clock speed and directory structure."
 	@echo "Please view Makefile.cosconfig and kernel/include/shared/cpu_ghz.h to make sure they're accurate."
 	@echo "Do _not_ 'git add' either of these files."
-	@cat /proc/cpuinfo | grep "model name" -m 1 | sed 's/.*\([0-9]\.[0-9]*\).*/\#define CPU_GHZ \1/' > ./kernel/include/shared/cpu_ghz.h
+	@cat /proc/cpuinfo | grep "cpu MHz" -m 1 | awk '{printf("#define CPU_GHZ %3.2f\n", $$4/1000)}' > ./kernel/include/shared/cpu_ghz.h
 	@if [ -z "`cat /proc/cpuinfo | grep \"physical id\"`" ]; then echo "#define NUM_CPU_SOCKETS 1" >> ./kernel/include/shared/cpu_ghz.h; else cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l | sed 's/.*\([0-9]\).*/\#define NUM_CPU_SOCKETS \1/' >> ./kernel/include/shared/cpu_ghz.h; fi
 	@pwd | sed 's/\(\/[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/\).*/HOME_DIR=\1/' > Makefile.cosconfig
 	@echo "CODE_DIR=`pwd`" >> Makefile.cosconfig


### PR DESCRIPTION
* Some CPUs won't put their base clock into their model, like AMD's.

Signed-off-by: msdx321 <msdx321@gmail.com>

### Summary of this Pull Request (PR)

Fix `make config-gen` under AMD system.

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [ ] Comments adhere to the Style Guide (SG)
- [ ] Spacing adhere's to the SG
- [ ] Naming adhere's to the SG
- [ ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ ] I've made an attempt to remove all redundant code
- [ ] I've considered ways in which my changes might impact existing code, and cleaned it up
- [ ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ ] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [ ] unit_pingpong
- [ ] unit_schedtests
- [ ] ...(add others here)
