### PR TITLE
Generalized the composer to work on 64 bit ELF binaries.

### DIFF
--- a/src/composer/src/build.rs
+++ b/src/composer/src/build.rs
@@ -78,7 +78,7 @@ fn tarball_create(
 fn constructor_tarball_create(
     id: &ComponentId,
     s: &SystemState,
-    b: &BuildState,
+    b: &dyn BuildState,
 ) -> Result<Option<String>, String> {
     let me = component(&s, &id);
     let tar_path = b.comp_file_path(&id, &"initfs_constructor.tar".to_string(), &s)?;
@@ -112,7 +112,7 @@ fn constructor_tarball_create(
 fn constructor_serialize_args(
     id: &ComponentId,
     s: &SystemState,
-    b: &BuildState,
+    b: &dyn BuildState,
 ) -> Result<String, String> {
     let mut sinvs = Vec::new();
     let mut ids = Vec::new();

--- a/src/composer/src/resources.rs
+++ b/src/composer/src/resources.rs
@@ -91,7 +91,7 @@ fn comp_config(_s: &SystemState, _id: &ComponentId, _cfg: &mut CompConfigState) 
 fn sched_config_serv_client(s: &SystemState, id: &ComponentId) -> Vec<ArgsKV> {
     let mut init = Vec::new();
 
-    let props: &PropertiesPass = s.get_properties();
+    let props: &dyn PropertiesPass = s.get_properties();
     if !props.service_is_a(&id, ServiceType::Scheduler) {
         return init;
     }
@@ -111,7 +111,7 @@ fn sched_config_serv_client(s: &SystemState, id: &ComponentId) -> Vec<ArgsKV> {
 fn sched_config_clients(s: &SystemState, id: &ComponentId) -> Vec<ArgsKV> {
     let mut init = Vec::new();
 
-    let props: &PropertiesPass = s.get_properties();
+    let props: &dyn PropertiesPass = s.get_properties();
     if !props.service_is_a(&id, ServiceType::Scheduler) {
         return init;
     }
@@ -157,7 +157,7 @@ fn cap2kvarg(capid: u32, cap: &CapRes) -> ArgsKV {
 }
 
 fn capmgr_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {
-    let props: &PropertiesPass = s.get_properties();
+    let props: &dyn PropertiesPass = s.get_properties();
     if !props.service_is_a(&id, ServiceType::CapMgr) {
         return;
     }
@@ -235,7 +235,7 @@ fn capmgr_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {
 }
 
 fn constructor_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {
-    let props: &PropertiesPass = s.get_properties();
+    let props: &dyn PropertiesPass = s.get_properties();
     if !props.service_is_a(&id, ServiceType::Constructor) {
         return;
     }

--- a/src/composer/src/symbols.rs
+++ b/src/composer/src/symbols.rs
@@ -1,16 +1,36 @@
+#[derive(Clone, Copy)]
 pub struct Symb<'a> {
     name: &'a str,
-    addr: u64
+    addr: u64,
+    stype: SymbType,
+}
+
+#[derive(PartialEq, Clone, Copy)]
+pub enum SymbType {
+    GlobalData,
+    GlobalFn,
+    Other,
 }
 
 impl<'a> Symb<'a> {
-    pub fn new(name: &'a str, addr: u64) -> Symb<'a> {
-        Symb { name: name, addr: addr }
+    pub fn new(name: &'a str, addr: u64, t: SymbType) -> Option<Symb<'a>> {
+	if t == SymbType::Other {
+	    return None;
+	}
+
+        Some(Symb {
+            name: name,
+            addr: addr,
+            stype: t,
+        })
     }
     pub fn name(&self) -> &'a str {
         self.name
     }
     pub fn addr(&self) -> u64 {
         self.addr
+    }
+    pub fn stype(&self) -> SymbType {
+	self.stype
     }
 }


### PR DESCRIPTION
- Fixed some of the `dyn` suggestions.
- Adapted all apis that were using `Entry32` to instead use our `Symb` type that maintains the lifetime constraints, but generalizes the word size.
- Use the `Entry` type while constructing `Symb` values to be generic across word sizes.
    Resolve the names at the time of processing the binary.
- Removed a ton of `&ElfFile<'a>` arguments as they are no longer required to perform name lookups.

### Summary of this Pull Request (PR)

This should generalize the composer to be able to work on 64 bit binaries.
I might be missing something that prevents working with 64 bit binaries, but I am relatively confident this should solve the issue.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):

@betahxy 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [x] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions) (rust autoformatter)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [x] ping_pong.toml
- [x] sched_ping_pong.toml