### PR TITLE
Fix modern GCC (11.1) build

### DIFF
--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -1,6 +1,6 @@
 # include ../../../Makefile.inc first!
 
-ARCH_CFLAGS =-m32 -D__x86__
+ARCH_CFLAGS =-m32 -D__x86__ -march=i686
 ARCH_ASFLAGS=$(ARCH_CFLAGS)
 ARCH_LDFLAGS=-melf_i386
 

--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -21,14 +21,13 @@ OPT= -O3
 
 CFLAGS=$(ARCH_CFLAGS) -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Wno-unused-function -fno-stack-protector -fno-omit-frame-pointer -Wno-unused-variable $(CINC) $(MUSLINC) $(OPT) $(SHARED_FLAGS)
 CXXFLAGS=-fno-exceptions -fno-threadsafe-statics -Wno-write-strings $(CFLAGS)
-LDFLAGS=$(ARCH_LDFLAGS) -no-pic
+LDFLAGS=$(ARCH_LDFLAGS)
 MUSLCFLAGS=$(CFLAGS) -lc -lgcc -Xlinker -r
 ASFLAGS=$(ARCH_ASFLAGS) $(CINC) $(SHARED_FLAGS)
 
 GCC_PIE=$(shell gcc -v 2>&1 | grep -c "\--enable-default-pie")
 ifeq ($(GCC_PIE),1)
 MUSLCFLAGS+=-no-pie
-LDFLAGS+=-no-pie
 CFLAGS+=-fno-pie
 CXXFLAGS+=-fno-pie
 endif

--- a/src/components/implementation/comp.ld
+++ b/src/components/implementation/comp.ld
@@ -69,4 +69,6 @@ SECTIONS
 	.bss : { *(.bss*) }
 
 	__crt_static_heap_ptr = .;
+
+	/DISCARD/ : { *(.note.gnu.property) }
 }

--- a/src/components/lib/libc/Makefile
+++ b/src/components/lib/libc/Makefile
@@ -77,7 +77,7 @@ clean:
 
 init:
 	$(info Building libc (musl)...)
-	cd $(MUSLDIR); ./configure "CFLAGS=-m32 -march=i686 -O3" "LDFLAGS=-Wl,-melf_i386" --disable-shared --target=i386; cd ..
+	cd $(MUSLDIR); ./configure "CFLAGS=-m32 -march=i686 -O3 -fno-stack-protector" "LDFLAGS=-Wl,-melf_i386" --disable-shared --target=i386; cd ..
 	make -C $(MUSLDIR)
 	make -C $(MUSLDIR) install
 	cp $(MUSLLIB)*.a .

--- a/src/components/lib/libc/Makefile
+++ b/src/components/lib/libc/Makefile
@@ -77,7 +77,7 @@ clean:
 
 init:
 	$(info Building libc (musl)...)
-	cd $(MUSLDIR); ./configure "CFLAGS=-m32 -O3" "LDFLAGS=-Wl,-melf_i386" --disable-shared --target=i386; cd ..
+	cd $(MUSLDIR); ./configure "CFLAGS=-m32 -march=i686 -O3" "LDFLAGS=-Wl,-melf_i386" --disable-shared --target=i386; cd ..
 	make -C $(MUSLDIR)
 	make -C $(MUSLDIR) install
 	cp $(MUSLLIB)*.a .

--- a/src/platform/i386/Makefile
+++ b/src/platform/i386/Makefile
@@ -6,7 +6,7 @@ AS := as --32 -g
 
 INCPATH := ../../kernel/include
 INCS    := -I$(INCPATH) -I$(INCPATH)/shared/
-CFLAGS  := -g3 -O3 -fcommon -ffreestanding -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -nostdinc -nostdlib -fno-pic -mno-red-zone $(INCS)
+CFLAGS  := -g3 -O3 -fcommon -fno-stack-protector -ffreestanding -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -nostdinc -nostdlib -fno-pic -mno-red-zone $(INCS)
 LDFLAGS := -nostdlib -fno-builtin -nostartfiles -nostdinc -nodefaultlibs
 
 KERNEL := kernel.img

--- a/src/platform/i386/Makefile
+++ b/src/platform/i386/Makefile
@@ -1,6 +1,6 @@
 include Makefile.src
 
-CC := gcc -m32
+CC := gcc -m32 -march=i686
 LD := ld -m elf_i386
 AS := as --32 -g
 

--- a/src/platform/i386/Makefile
+++ b/src/platform/i386/Makefile
@@ -6,7 +6,7 @@ AS := as --32 -g
 
 INCPATH := ../../kernel/include
 INCS    := -I$(INCPATH) -I$(INCPATH)/shared/
-CFLAGS  := -g3 -O3 -ffreestanding -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -nostdinc -nostdlib -fno-pic -mno-red-zone $(INCS)
+CFLAGS  := -g3 -O3 -fcommon -ffreestanding -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -nostdinc -nostdlib -fno-pic -mno-red-zone $(INCS)
 LDFLAGS := -nostdlib -fno-builtin -nostartfiles -nostdinc -nodefaultlibs
 
 KERNEL := kernel.img


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Fix modern GCC build issue, composite can build on gcc 11.1.0.

One build script issue need to tackle in future, `-march=i686` was passed to `components/Makefile.comp` and `components/lib/libc/Makefile`, this is depend on target architecture therefore should not hard coded in makefile.


Test the compose result with `sched.toml`:

```SeaBIOS (version ArchLinux 1.14.0-1)


iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+2FF913A0+2FEF13A0 CA00
                                                                               


Booting from ROM..Initial component found:
	- [c22ab000, c2473858)
Memory regions:
	- 0 (Available): [00000000, 0009fc00) sz = 0MB + 639KB
	- 1 (Reserved ): [0009fc00, 000a0000) sz = 0MB + 1KB
	- 2 (Reserved ): [000f0000, 00100000) sz = 0MB + 64KB
	- 3 (Available): [00100000, 2ffe0000) sz = 766MB + 896KB
	  memory usable at boot time: 2db6c7a8 (731 MB + 433 KB)
	- 4 (Reserved ): [2ffe0000, 30000000) sz = 0MB + 128KB
	- 5 (Reserved ): [fffc0000, 100000000) sz = 0MB + 256KB
	Amount of wasted memory due to layout is 0 MB + 0x7a8 B
Processor information:
	Vendor: GenuineIntel
	Features [rdtsc fpu superpages sysenter/exit apic ]
Initializing virtual memory
	Setting up initial page directory.
ACPI initialization
	Found good RSDP @ c00f5b20
Initializing HPET @ f03e18a5
	Checksum is OK
	Addr: 00000000fed00000
	hpet: f0500000
	Set HPET @ f0500000
Initializing LAPIC @ f03e182d
	MADT length 120 (base struct 44)
	LAPIC found: coreid 0, apicid 0 flags 1
	I/O APIC found: ioapicid 0, addr fec00000, int offset 0
	Interrupt controller type 2: ignoring
	Interrupt controller type 2: ignoring
	Interrupt controller type 2: ignoring
	Interrupt controller type 2: ignoring
	Interrupt controller type 2: ignoring
	Interrupt controller type 4: ignoring
	APICs processed, 1 cores
	Checksum is OK
	lapic: f0600000
	Found ACPI FACP and DSDT
	FACP and DSDT parsed and will be used for shutdown
	LAPIC: TSC-Deadline Mode not supported! Configuring Oneshot Mode!
Enabling timer @ f0500000 with tick granularity 10000 picoseconds
Setting up the booter component.
	Creating 1 booter VM PTEs from [c2486000,c2487000) to [400000,5ce7dc).
	Mapping in booter VM (@ [0x400000, 0x418ba4))
	Mapping in booter VM (@ [0x419000, 0x5c1000))
	Mapping in booter VM (@ [0x5c1000, 0x5ceff4))
	Booter elf object: RO - [400000, 418ba4), RW - [419000, 5ce7dc)
	Creating 183 untyped memory PTEs from [c2487000,c253e000) to [400000,2dea2000).
	Mapping in untyped memory (@ [0x400000, 0x2ddeb000))
	Capability table and page-table created.
	Created boot component structure from page-table and capability-table.
	Creating initial threads, tcaps, and rcv end-points in boot-component.
	Boot component initialization complete.
Upcall into boot component at ip 0x402850 for cpu: 0 with tid: 1
------------------[ Kernel boot complete ]------------------
Components (4):
tests.unit_schedcomp.global.schedtest: 4
		 elf obj: ro [0x400000, 0x40d0f8), data [0x40e000, 0x45400c), bss [0x45400c, 0x454b1c).
sched.root_fprr.global.sched: 3
		 elf obj: ro [0x400000, 0x42a588), data [0x42b000, 0x47100c), bss [0x47100c, 0x49a29c).
capmgr.simple.global.capmgr: 2
		 elf obj: ro [0x400000, 0x4227e0), data [0x423000, 0x46900c), bss [0x46900c, 0x54d75c).
no_interface.llbooter.global.booter: 1
Execution schedule:
	Created scheduling execution for 2
Capability table delegations (1 capability managers):
	Capmgr 2:
		Capability #56: comp for component 4
		Capability #54: pgtbl for component 4
		Capability #52: captbl for component 4
		Capability #48: comp for component 3
		Capability #46: pgtbl for component 3
		Capability #44: captbl for component 3
Synchronous invocations (33):
sinv sched_blkpt_trigger cap 40
	sched_blkpt_trigger (4->3):	client_fn @ 0x401050, client_ucap @ 0x41208c, server_fn @ 0x4008e0
sinv init_done cap 44
	init_done (4->3):	client_fn @ 0x400520, client_ucap @ 0x412044, server_fn @ 0x400b10
sinv capmgr_create_noop cap 48
	capmgr_create_noop (4->2):	client_fn @ 0x401050, client_ucap @ 0x4120ec, server_fn @ 0x4032b0
sinv sched_thd_wakeup cap 52
	sched_thd_wakeup (4->3):	client_fn @ 0x401050, client_ucap @ 0x41205c, server_fn @ 0x400820
sinv sched_thd_param_set cap 56
	sched_thd_param_set (4->3):	client_fn @ 0x401050, client_ucap @ 0x4120c8, server_fn @ 0x4009f0
sinv sched_thd_delete cap 60
	sched_thd_delete (4->3):	client_fn @ 0x401050, client_ucap @ 0x4120e0, server_fn @ 0x400a50
sinv sched_blkpt_free cap 64
	sched_blkpt_free (4->3):	client_fn @ 0x401050, client_ucap @ 0x412080, server_fn @ 0x4008b0
sinv sched_blkpt_alloc cap 68
	sched_blkpt_alloc (4->3):	client_fn @ 0x401050, client_ucap @ 0x412074, server_fn @ 0x400880
sinv sched_aep_create_closure cap 72
	sched_aep_create_closure (4->3):	client_fn @ 0x4005e0, client_ucap @ 0x4120bc, server_fn @ 0x4009b0
sinv sched_thd_exit cap 76
	sched_thd_exit (4->3):	client_fn @ 0x401050, client_ucap @ 0x4120d4, server_fn @ 0x400a20
sinv init_exit cap 80
	init_exit (4->3):	client_fn @ 0x401050, client_ucap @ 0x412050, server_fn @ 0x400b40
sinv sched_thd_block cap 84
	sched_thd_block (4->3):	client_fn @ 0x401050, client_ucap @ 0x412068, server_fn @ 0x400850
sinv sched_thd_block_timeout cap 88
	sched_thd_block_timeout (4->3):	client_fn @ 0x400580, client_ucap @ 0x4120a4, server_fn @ 0x400940
sinv sched_blkpt_block cap 92
	sched_blkpt_block (4->3):	client_fn @ 0x401050, client_ucap @ 0x412098, server_fn @ 0x400910
sinv sched_thd_create_closure cap 96
	sched_thd_create_closure (4->3):	client_fn @ 0x401050, client_ucap @ 0x4120b0, server_fn @ 0x400980
sinv init_exit cap 40
	init_exit (3->2):	client_fn @ 0x4016e0, client_ucap @ 0x42f050, server_fn @ 0x4031b0
sinv memmgr_shared_page_map cap 44
	memmgr_shared_page_map (3->2):	client_fn @ 0x400fb0, client_ucap @ 0x42f0ec, server_fn @ 0x403250
sinv memmgr_heap_page_allocn cap 48
	memmgr_heap_page_allocn (3->2):	client_fn @ 0x4016e0, client_ucap @ 0x42f0d4, server_fn @ 0x4031e0
sinv capmgr_asnd_key_create cap 52
	capmgr_asnd_key_create (3->2):	client_fn @ 0x4016e0, client_ucap @ 0x42f0c8, server_fn @ 0x402f10
sinv capmgr_asnd_create cap 56
	capmgr_asnd_create (3->2):	client_fn @ 0x4016e0, client_ucap @ 0x42f0b0, server_fn @ 0x402eb0
sinv capmgr_thd_create_ext cap 60
	capmgr_thd_create_ext (3->2):	client_fn @ 0x400cb0, client_ucap @ 0x42f074, server_fn @ 0x402d70
sinv capmgr_aep_create_thunk cap 64
	capmgr_aep_create_thunk (3->2):	client_fn @ 0x400d00, client_ucap @ 0x42f08c, server_fn @ 0x402df0
sinv capmgr_aep_create_ext cap 68
	capmgr_aep_create_ext (3->2):	client_fn @ 0x400db0, client_ucap @ 0x42f098, server_fn @ 0x402e30
sinv capmgr_thd_create_thunk cap 72
	capmgr_thd_create_thunk (3->2):	client_fn @ 0x400c60, client_ucap @ 0x42f068, server_fn @ 0x402d30
sinv memmgr_shared_page_allocn cap 76
	memmgr_shared_page_allocn (3->2):	client_fn @ 0x400f60, client_ucap @ 0x42f0e0, server_fn @ 0x403210
sinv capmgr_asnd_rcv_create cap 80
	capmgr_asnd_rcv_create (3->2):	client_fn @ 0x4016e0, client_ucap @ 0x42f0bc, server_fn @ 0x402ee0
sinv capmgr_rcv_create cap 84
	capmgr_rcv_create (3->2):	client_fn @ 0x400bd0, client_ucap @ 0x42f0a4, server_fn @ 0x402e70
sinv init_done cap 88
	init_done (3->2):	client_fn @ 0x400b70, client_ucap @ 0x42f044, server_fn @ 0x403180
sinv capmgr_initaep_create cap 92
	capmgr_initaep_create (3->2):	client_fn @ 0x400e60, client_ucap @ 0x42f080, server_fn @ 0x402db0
sinv capmgr_initthd_create cap 96
	capmgr_initthd_create (3->2):	client_fn @ 0x400c10, client_ucap @ 0x42f05c, server_fn @ 0x402cf0
sinv init_exit cap 60
	init_exit (2->1):	client_fn @ 0x403a20, client_ucap @ 0x427050, server_fn @ 0x401f40
sinv init_done cap 64
	init_done (2->1):	client_fn @ 0x4032e0, client_ucap @ 0x427044, server_fn @ 0x401f10
sinv addr_get cap 68
	addr_get (2->1):	client_fn @ 0x403a20, client_ucap @ 0x42705c, server_fn @ 0x401f70
Kernel resources created, booting components!
Initializing component 2 (executing cos_init).
Starting the capability manager.
Capmgr: processing 6 capabilities for components that have already been booted
	Creating component tests.unit_schedcomp.global.schedtest: id 4, caps (captbl:52, pgtbl:54,comp:56), captbl frontier 100, heap pointer 4542464, scheduler 3
	Creating component sched.root_fprr.global.sched: id 3, caps (captbl:44, pgtbl:46,comp:48), captbl frontier 100, heap pointer 4829184, scheduler 2
Capmgr: 1 components that need execution
	Created scheduling execution for 3
Component 2 initialization complete, awaiting main execution.
Switching to main in component 2.
Executing main in component 2.
Initializing component 3 (executing cos_init).
Scheduler 3 initializing.
	Sched 3: 1 components that need execution
	Sched 3: 4 is the 0th component to initialize
Component 3 initialization complete, awaiting main execution.
Switching to main in component 3.
Executing main in component 3.
Scheduler 3: Running initialization thread.
	Sched 3: creating thread 7 for component 4.
(0,7,4) DBG:Unit-test scheduling manager component
Scheduler 3, initialization completed.
(0,8,4) DBG:Test successful! Highest was scheduled only!
(0,8,4) DBG:Test successful! We swapped back and forth!
(0,8,4) DBG:Done testing, spinning...
```


### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):

@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

No SG for build script.

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [-] sched.toml
