### PR TITLE
Update Tools necessary for Composite (missing/obsolete python)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -11,9 +11,17 @@ sudo apt-get -y install build-essential
 sudo apt-get -y install xorriso  
 sudo apt-get -y install curl  
 sudo apt-get -y install python
-sudo apt-get -y install cargo
 sudo apt-get -y install gdb
 ```
+
+[Install Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
+
+```
+curl https://sh.rustup.rs -sSf | sh
+```
+
+You might need to restart your shell to be able to use cargo.
+
 If you want or need Rust on composite, also follow the steps in `rust_with_composite.md`
 ## Getting and building
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,9 @@ sudo apt-get -y install cmake
 sudo apt-get -y install build-essential  
 sudo apt-get -y install xorriso  
 sudo apt-get -y install curl  
-sudo apt-get -y install python-is-python3
+sudo apt-get -y install python
+sudo apt-get -y install cargo
+sudo apt-get -y install gdb
 ```
 If you want or need Rust on composite, also follow the steps in `rust_with_composite.md`
 ## Getting and building

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ sudo apt-get -y install cmake
 sudo apt-get -y install build-essential  
 sudo apt-get -y install xorriso  
 sudo apt-get -y install curl  
-sudo apt-get -y install python
+sudo apt-get -y install python-is-python3
 ```
 If you want or need Rust on composite, also follow the steps in `rust_with_composite.md`
 ## Getting and building


### PR DESCRIPTION
### Summary of this Pull Request (PR)

**Updated tools necessary for composite in doc/README.md**

### Intent for your PR

Update tools necessary for Composite.

I have gotten this error several times when setting up environment after running `./cos build`:

```
/bin/sh: 1: gdb: not found
cd composer/ ; cargo build
/bin/sh: 1: cargo: not found
make: *** [Makefile:14: composer] Error 127
make: Leaving directory '/home/ubuntu/composite/src'
```

After installing:

```
sudo apt-get -y install cargo
sudo apt-get -y install gdb
```

I am able to `./cos build` successfully.

Choose one (Mandatory):

- [X] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [X] Comments adhere to the Style Guide (SG)
- [X] Spacing adhere's to the SG
- [X] Naming adhere's to the SG
- [X] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [X] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [X] I've made an attempt to remove all redundant code
- [X] I've considered ways in which my changes might impact existing code, and cleaned it up
- [X] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [X] I've commented appropriately where code is tricky
- [X] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [ ] unit_pingpong
- [ ] unit_schedtests
