### PR TITLE
Added flags parameter to PGTBL CAPTBL_OP_CPY

### DIFF
--- a/src/components/implementation/tests/unit_defcompinfo/unit_defcompinfo.c
+++ b/src/components/implementation/tests/unit_defcompinfo/unit_defcompinfo.c
@@ -177,7 +177,7 @@ cos_init(void)
 				assert(src_pg);
 				memcpy((void *)src_pg, (void *)(BOOT_MEM_VM_BASE + addr), PAGE_SIZE);
 
-				dst_pg = cos_mem_alias(child_ci, ci, src_pg);
+				dst_pg = cos_mem_alias(child_ci, ci, src_pg, COS_PAGE_READABLE | COS_PAGE_WRITABLE);
 				assert(dst_pg);
 			}
 

--- a/src/components/lib/crt/crt.c
+++ b/src/components/lib/crt/crt.c
@@ -283,7 +283,7 @@ crt_comp_create_from(struct crt_comp *c, char *name, compid_t id, struct crt_chk
 	assert(comp_info->cos_this_spd_id == 0);
 	comp_info->cos_this_spd_id = id;
 
-	if (c->ro_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem, round_up_to_page(c->ro_sz), COS_PAGE_READABLE | COS_PAGE_WRITABLE)) return -ENOMEM;
+	if (c->ro_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem, round_up_to_page(c->ro_sz), COS_PAGE_READABLE)) return -ENOMEM;
 	if (c->rw_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem + round_up_to_page(c->ro_sz), c->tot_sz_mem - round_to_page(c->ro_sz), COS_PAGE_READABLE | COS_PAGE_WRITABLE)) return -ENOMEM;
 
 	/* FIXME: cos_time.h assumes we have access to this... */
@@ -356,7 +356,7 @@ crt_comp_create(struct crt_comp *c, char *name, compid_t id, void *elf_hdr, vadd
 	c->n_sinvs = 0;
 	memset(c->sinvs, 0, sizeof(c->sinvs));
 
-	if (c->ro_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem, round_up_to_page(ro_sz), COS_PAGE_READABLE | COS_PAGE_WRITABLE)) return -ENOMEM;
+	if (c->ro_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem, round_up_to_page(ro_sz), COS_PAGE_READABLE)) return -ENOMEM;
 	if (c->rw_addr != cos_mem_aliasn(ci, root_ci, (vaddr_t)mem + round_up_to_page(ro_sz), round_up_to_page(data_sz + bss_sz), COS_PAGE_READABLE | COS_PAGE_WRITABLE)) return -ENOMEM;
 
 	/* FIXME: cos_time.h assumes we have access to this... */

--- a/src/components/lib/kernel/cos_kernel_api.c
+++ b/src/components/lib/kernel/cos_kernel_api.c
@@ -1062,7 +1062,7 @@ cos_rcv(arcvcap_t rcv, rcv_flags_t flags, int *rcvd)
 }
 
 vaddr_t
-cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags)
+cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long perm_flags)
 {
 	size_t i;
 	vaddr_t dst, first_dst;
@@ -1075,30 +1075,30 @@ cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t s
 	first_dst = dst;
 
 	for (i = 0; i < sz; i += PAGE_SIZE, src += PAGE_SIZE, dst += PAGE_SIZE) {
-		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, newflags)) return 0;
+		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, perm_flags)) return 0;
 	}
 
 	return first_dst;
 }
 
 vaddr_t
-cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags)
+cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long perm_flags)
 {
-	return cos_mem_aliasn(dstci, srcci, src, PAGE_SIZE, newflags);
+	return cos_mem_aliasn(dstci, srcci, src, PAGE_SIZE, perm_flags);
 }
 
 int
-cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags)
+cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long perm_flags)
 {
 	assert(srcci && dstci);
 
-	if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, newflags)) BUG();
+	if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, perm_flags)) BUG();
 
 	return 0;
 }
 
 int
-cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags)
+cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long perm_flags)
 {
 	size_t i;
 	size_t npages;
@@ -1108,7 +1108,7 @@ cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *
 
 	npages = sz / PAGE_SIZE;
 	for (i=0; i < npages; i++) {
-		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src + i * PAGE_SIZE, dstci->pgtbl_cap, dst + i * PAGE_SIZE, newflags)) BUG();
+		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src + i * PAGE_SIZE, dstci->pgtbl_cap, dst + i * PAGE_SIZE, perm_flags)) BUG();
 	}
 
 	return 0;

--- a/src/components/lib/kernel/cos_kernel_api.c
+++ b/src/components/lib/kernel/cos_kernel_api.c
@@ -1062,7 +1062,7 @@ cos_rcv(arcvcap_t rcv, rcv_flags_t flags, int *rcvd)
 }
 
 vaddr_t
-cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz)
+cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags)
 {
 	size_t i;
 	vaddr_t dst, first_dst;
@@ -1075,30 +1075,30 @@ cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t s
 	first_dst = dst;
 
 	for (i = 0; i < sz; i += PAGE_SIZE, src += PAGE_SIZE, dst += PAGE_SIZE) {
-		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, PAGE_ORDER)) return 0;
+		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, newflags)) return 0;
 	}
 
 	return first_dst;
 }
 
 vaddr_t
-cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src)
+cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags)
 {
-	return cos_mem_aliasn(dstci, srcci, src, PAGE_SIZE);
+	return cos_mem_aliasn(dstci, srcci, src, PAGE_SIZE, newflags);
 }
 
 int
-cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src)
+cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags)
 {
 	assert(srcci && dstci);
 
-	if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, PAGE_ORDER)) BUG();
+	if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src, dstci->pgtbl_cap, dst, newflags)) BUG();
 
 	return 0;
 }
 
 int
-cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz)
+cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags)
 {
 	size_t i;
 	size_t npages;
@@ -1108,7 +1108,7 @@ cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *
 
 	npages = sz / PAGE_SIZE;
 	for (i=0; i < npages; i++) {
-		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src + i * PAGE_SIZE, dstci->pgtbl_cap, dst + i * PAGE_SIZE, PAGE_ORDER)) BUG();
+		if (call_cap_op(srcci->pgtbl_cap, CAPTBL_OP_CPY, src + i * PAGE_SIZE, dstci->pgtbl_cap, dst + i * PAGE_SIZE, newflags)) BUG();
 	}
 
 	return 0;

--- a/src/components/lib/kernel/cos_kernel_api.h
+++ b/src/components/lib/kernel/cos_kernel_api.h
@@ -160,10 +160,10 @@ int cos_sched_rcv(arcvcap_t rcv, rcv_flags_t flags, tcap_time_t timeout, int *rc
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
 
-vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
-vaddr_t cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz);
-int     cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);
-int     cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz);
+vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags);
+vaddr_t cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags);
+int     cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags);
+int     cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags);
 vaddr_t cos_mem_move(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
 int     cos_mem_move_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);
 int     cos_mem_remove(pgtblcap_t pt, vaddr_t addr);

--- a/src/components/lib/kernel/cos_kernel_api.h
+++ b/src/components/lib/kernel/cos_kernel_api.h
@@ -160,10 +160,10 @@ int cos_sched_rcv(arcvcap_t rcv, rcv_flags_t flags, tcap_time_t timeout, int *rc
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
 
-vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags);
-vaddr_t cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags);
-int     cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long newflags);
-int     cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long newflags);
+vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, unsigned long perm_flags);
+vaddr_t cos_mem_aliasn(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long perm_flags);
+int     cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, unsigned long perm_flags);
+int     cos_mem_alias_atn(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src, size_t sz, unsigned long perm_flags);
 vaddr_t cos_mem_move(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
 int     cos_mem_move_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);
 int     cos_mem_remove(pgtblcap_t pt, vaddr_t addr);

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -108,7 +108,7 @@ kmem_deact_pre(struct cap_header *ch, struct captbl *ct, capid_t pgtbl_cap, capi
                unsigned long **p_pte, unsigned long *v)
 {
 	struct cap_pgtbl *cap_pt;
-	u32_t             flags, old_v, pa;
+	word_t            flags, old_v, pa;
 	u64_t             curr;
 	int               ret;
 
@@ -225,7 +225,7 @@ err:
  *
  */
 static inline int
-cap_cpy(struct captbl *t, capid_t cap_to, capid_t capin_to, capid_t cap_from, capid_t capin_from, vaddr_t order)
+cap_cpy(struct captbl *t, capid_t cap_to, capid_t capin_to, capid_t cap_from, capid_t capin_from, word_t flags)
 {
 	struct cap_header *ctto, *ctfrom;
 	int                sz, ret;
@@ -283,7 +283,7 @@ cap_cpy(struct captbl *t, capid_t cap_to, capid_t capin_to, capid_t cap_from, ca
 		}
 		__cap_capactivate_post(ctto, type);
 	} else if (cap_type == CAP_PGTBL) {
-		ret = chal_pgtbl_cpy(t, cap_to, capin_to, (struct cap_pgtbl*)ctfrom, capin_from, cap_type, order);
+		ret = chal_pgtbl_cpy(t, cap_to, capin_to, (struct cap_pgtbl*)ctfrom, capin_from, cap_type, flags);
 	} else {
 		ret = -EINVAL;
 	}
@@ -308,7 +308,7 @@ cap_move(struct captbl *t, capid_t cap_to, capid_t capin_to, capid_t cap_from, c
 		return -EPERM;
 	} else if (cap_type == CAP_PGTBL) {
 		unsigned long *f, old_v, *moveto, old_v_to;
-		u32_t          flags;
+		word_t         flags;
 
 		ctto = captbl_lkup(t, cap_to);
 		if (unlikely(!ctto)) return -ENOENT;
@@ -1337,9 +1337,9 @@ static int __attribute__((noinline)) composite_syscall_slowpath(struct pt_regs *
 			vaddr_t source_addr = __userregs_get1(regs);
 			capid_t dest_pt     = __userregs_get2(regs);
 			vaddr_t dest_addr   = __userregs_get3(regs);
-			vaddr_t order       = __userregs_get4(regs);
+			word_t  flags       = __userregs_get4(regs);
 
-			ret = cap_cpy(ct, dest_pt, dest_addr, source_pt, source_addr, order);
+			ret = cap_cpy(ct, dest_pt, dest_addr, source_pt, source_addr, flags);
 			break;
 		}
 		case CAPTBL_OP_MEMMOVE: {
@@ -1596,7 +1596,7 @@ static int __attribute__((noinline)) composite_syscall_slowpath(struct pt_regs *
 			paddr_t           pa    = __userregs_get3(regs);
 			struct cap_pgtbl *ptc;
 			unsigned long *   pte;
-			u32_t             flags;
+			word_t            flags;
 
 			/*
 			 * FIXME: This is broken.  It should only be

--- a/src/kernel/include/pgtbl.h
+++ b/src/kernel/include/pgtbl.h
@@ -53,24 +53,24 @@ struct tlb_quiescence {
 extern struct tlb_quiescence tlb_quiescence[NUM_CPU] CACHE_ALIGNED;
 
 int            tlb_quiescence_check(u64_t timestamp);
-int            pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order);
-int            pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order);
+int            pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order);
+int            pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order);
 int            pgtbl_mapping_mod(pgtbl_t pt, u32_t addr, u32_t flags, u32_t *prevflags);
-int            pgtbl_mapping_del(pgtbl_t pt, u32_t addr, u32_t liv_id);
+int            pgtbl_mapping_del(pgtbl_t pt, vaddr_t addr, u32_t liv_id);
 int            pgtbl_mapping_del_direct(pgtbl_t pt, u32_t addr);
-void          *pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, u32_t *flags, u32_t start_lvl, u32_t end_lvl);
-int            pgtbl_ispresent(u32_t flags);
-unsigned long *pgtbl_lkup(pgtbl_t pt, u32_t addr, u32_t *flags);
-unsigned long *pgtbl_lkup_pte(pgtbl_t pt, u32_t addr, u32_t *flags);
-unsigned long *pgtbl_lkup_pgd(pgtbl_t pt, u32_t addr, u32_t *flags);
+void          *pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, word_t *flags, u32_t start_lvl, u32_t end_lvl);
+int            pgtbl_ispresent(word_t flags);
+unsigned long *pgtbl_lkup(pgtbl_t pt, vaddr_t addr, word_t *flags);
+unsigned long *pgtbl_lkup_pte(pgtbl_t pt, vaddr_t addr, word_t *flags);
+unsigned long *pgtbl_lkup_pgd(pgtbl_t pt, vaddr_t addr, word_t *flags);
 int            pgtbl_get_cosframe(pgtbl_t pt, vaddr_t frame_addr, paddr_t *cosframe, vaddr_t *order);
-vaddr_t        pgtbl_translate(pgtbl_t pt, u32_t addr, u32_t *flags);
+vaddr_t        pgtbl_translate(pgtbl_t pt, vaddr_t addr, word_t *flags);
 pgtbl_t        pgtbl_create(void *page, void *curr_pgtbl);
 int            pgtbl_activate(struct captbl *t, unsigned long cap, unsigned long capin, pgtbl_t pgtbl, u32_t lvl);
 int            pgtbl_deactivate(struct captbl *t, struct cap_captbl *dest_ct_cap, unsigned long capin, livenessid_t lid,
                                 capid_t pgtbl_cap, capid_t cosframe_addr, const int root);
 int            pgtbl_mapping_scan(struct cap_pgtbl *pt);
-int            pgtbl_quie_check(u32_t orig_v);
+int            pgtbl_quie_check(word_t orig_v);
 void           pgtbl_init_pte(void *pte);
 
 static inline void
@@ -109,18 +109,18 @@ int            chal_pgtbl_activate(struct captbl *t, unsigned long cap, unsigned
 int            chal_pgtbl_deactivate(struct captbl *t, struct cap_captbl *dest_ct_cap, unsigned long capin,
                                      livenessid_t lid, capid_t pgtbl_cap, capid_t cosframe_addr, const int root);
 
-int            chal_pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order);
-int            chal_pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order);
+int            chal_pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order);
+int            chal_pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order);
 /* This function updates flags of an existing mapping. */
 int            chal_pgtbl_mapping_mod(pgtbl_t pt, vaddr_t addr, u32_t flags, u32_t *prevflags);
 int            chal_pgtbl_mapping_del(pgtbl_t pt, vaddr_t addr, u32_t liv_id);
 int            chal_pgtbl_mapping_del_direct(pgtbl_t pt, u32_t addr);
 int            chal_pgtbl_mapping_scan(struct cap_pgtbl *pt);
-void          *chal_pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, u32_t *flags, u32_t start_lvl, u32_t end_lvl);
-int            chal_pgtbl_ispresent(u32_t flags);
-unsigned long *chal_pgtbl_lkup(pgtbl_t pt, u32_t addr, u32_t *flags);
-unsigned long *chal_pgtbl_lkup_pte(pgtbl_t pt, u32_t addr, u32_t *flags);
-unsigned long *chal_pgtbl_lkup_pgd(pgtbl_t pt, u32_t addr, u32_t *flags);
+void          *chal_pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, word_t *flags, u32_t start_lvl, u32_t end_lvl);
+int            chal_pgtbl_ispresent(word_t flags);
+unsigned long *chal_pgtbl_lkup(pgtbl_t pt, vaddr_t addr, word_t *flags);
+unsigned long *chal_pgtbl_lkup_pte(pgtbl_t pt, vaddr_t addr, word_t *flags);
+unsigned long *chal_pgtbl_lkup_pgd(pgtbl_t pt, vaddr_t addr, word_t *flags);
 int            chal_pgtbl_get_cosframe(pgtbl_t pt, vaddr_t frame_addr, paddr_t *cosframe, vaddr_t *order);
 pgtbl_t        chal_pgtbl_create(void *page, void *curr_pgtbl);
 int            chal_pgtbl_quie_check(u32_t orig_v);

--- a/src/kernel/pgtbl.c
+++ b/src/kernel/pgtbl.c
@@ -38,13 +38,13 @@ pgtbl_deactivate(struct captbl *t, struct cap_captbl *dest_ct_cap, unsigned long
 }
 
 int
-pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order)
+pgtbl_mapping_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order)
 {
 	return chal_pgtbl_mapping_add(pt, addr, page, flags, order);
 }
 
 int
-pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, u32_t flags, u32_t order)
+pgtbl_cosframe_add(pgtbl_t pt, vaddr_t addr, paddr_t page, word_t flags, u32_t order)
 {
 	return chal_pgtbl_cosframe_add(pt, addr, page, flags, order);
 }
@@ -56,7 +56,7 @@ pgtbl_mapping_mod(pgtbl_t pt, u32_t addr, u32_t flags, u32_t *prevflags)
 }
 
 int
-pgtbl_mapping_del(pgtbl_t pt, u32_t addr, u32_t liv_id)
+pgtbl_mapping_del(pgtbl_t pt, vaddr_t addr, u32_t liv_id)
 {
 	return chal_pgtbl_mapping_del(pt, addr, liv_id);
 }
@@ -78,31 +78,31 @@ pgtbl_mapping_scan(struct cap_pgtbl *pt)
 }
 
 void *
-pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, u32_t *flags, u32_t start_lvl, u32_t end_lvl)
+pgtbl_lkup_lvl(pgtbl_t pt, vaddr_t addr, word_t *flags, u32_t start_lvl, u32_t end_lvl)
 {
 	return chal_pgtbl_lkup_lvl(pt, addr, flags, start_lvl, end_lvl);
 }
 
 int
-pgtbl_ispresent(u32_t flags)
+pgtbl_ispresent(word_t flags)
 {
 	return chal_pgtbl_ispresent(flags);
 }
 
 unsigned long *
-pgtbl_lkup(pgtbl_t pt, u32_t addr, u32_t *flags)
+pgtbl_lkup(pgtbl_t pt, vaddr_t addr, word_t *flags)
 {
 	return chal_pgtbl_lkup(pt, addr, flags);
 }
 
 unsigned long *
-pgtbl_lkup_pte(pgtbl_t pt, u32_t addr, u32_t *flags)
+pgtbl_lkup_pte(pgtbl_t pt, vaddr_t addr, word_t *flags)
 {
 	return chal_pgtbl_lkup_pte(pt, addr, flags);
 }
 
 unsigned long *
-pgtbl_lkup_pgd(pgtbl_t pt, u32_t addr, u32_t *flags)
+pgtbl_lkup_pgd(pgtbl_t pt, vaddr_t addr, word_t *flags)
 {
 	return chal_pgtbl_lkup_pgd(pt, addr, flags);
 }
@@ -114,7 +114,7 @@ pgtbl_get_cosframe(pgtbl_t pt, vaddr_t frame_addr, paddr_t *cosframe, vaddr_t *o
 }
 
 vaddr_t
-pgtbl_translate(pgtbl_t pt, u32_t addr, u32_t *flags)
+pgtbl_translate(pgtbl_t pt, word_t addr, word_t *flags)
 {
 	return (vaddr_t)pgtbl_lkup(pt, addr, flags);
 }
@@ -126,7 +126,7 @@ pgtbl_create(void *page, void *curr_pgtbl)
 }
 
 int
-pgtbl_quie_check(u32_t orig_v)
+pgtbl_quie_check(word_t orig_v)
 {
 	return chal_pgtbl_quie_check(orig_v);
 }

--- a/src/platform/i386/boot_comp.c
+++ b/src/platform/i386/boot_comp.c
@@ -169,7 +169,7 @@ boot_pgtbl_mappings_add(struct captbl *ct, capid_t pgdcap, capid_t ptecap, const
 		u8_t *  p     = kern_vaddr + i * PAGE_SIZE;
 		paddr_t pf    = chal_va2pa(p);
 		unsigned long   mapat = (unsigned long)user_vaddr + i * PAGE_SIZE;
-		u32_t flags = 0;
+		word_t flags = 0;
 
 		if (uvm && pgtbl_mapping_add(pgtbl, mapat, pf, X86_PGTBL_USER_DEF, PAGE_ORDER)) assert(0);
 		if (!uvm && pgtbl_cosframe_add(pgtbl, mapat, pf, X86_PGTBL_COSFRAME, PAGE_ORDER)) assert(0);
@@ -341,8 +341,8 @@ kern_boot_comp(const cpuid_t cpu_id)
 void
 kern_boot_upcall(void)
 {
-	void *entry = (void *)mem_bootc_entry();
-	u32_t flags = 0;
+	void  *entry = (void *)mem_bootc_entry();
+	word_t flags = 0;
 	void *p;
 
 	assert(get_cpuid() >= 0);

--- a/src/platform/i386/chal/chal_proto.h
+++ b/src/platform/i386/chal/chal_proto.h
@@ -5,17 +5,19 @@
 /* Page table platform-dependent definitions */
 #define PGTBL_PAGEIDX_SHIFT (12)
 #define PGTBL_FRAME_BITS (32 - PGTBL_PAGEIDX_SHIFT)
-#define PGTBL_FLAG_MASK ((1 << PGTBL_PAGEIDX_SHIFT) - 1)
-#define PGTBL_FRAME_MASK (~PGTBL_FLAG_MASK)
 
 #if defined(__x86_64__)
 #define PGTBL_ENTRY_ADDR_MASK 0xfffffffffffff000
 #define PGTBL_DEPTH 4
 #define PGTBL_ENTRY_ORDER 9
+#define PGTBL_FLAG_MASK 0xf800000000000fff
+#define PGTBL_FRAME_MASK (~PGTBL_FLAG_MASK)
 #elif defined(__i386__)
 #define PGTBL_ENTRY_ADDR_MASK 0xfffff000
 #define PGTBL_DEPTH 2
 #define PGTBL_ENTRY_ORDER 10
+#define PGTBL_FLAG_MASK ((1 << PGTBL_PAGEIDX_SHIFT) - 1)
+#define PGTBL_FRAME_MASK (~PGTBL_FLAG_MASK)
 #endif
 
 #define PGTBL_ENTRY (1 << PGTBL_ENTRY_ORDER)

--- a/src/platform/i386/chal/shared/cos_config.h
+++ b/src/platform/i386/chal/shared/cos_config.h
@@ -164,6 +164,15 @@
                             /* 30/1G   31/2G */ \
                                -1,     -1 \
 
+/* PTE user pagetable modifiable flags */
+#define COS_PAGE_READABLE (0)
+#define COS_PAGE_WRITABLE (1ul << 1)
+#define COS_PAGE_PKEY0    (1ul << 59)
+#define COS_PAGE_PKEY1    (1ul << 60)
+#define COS_PAGE_PKEY2    (1ul << 61)
+#define COS_PAGE_PKEY3    (1ul << 62)
+#define COS_PAGE_XDISABLE (1ul << 63)
+
 #elif defined(__i386__)
 #define COS_PGTBL_DEPTH 2
 #define COS_PGTBL_ORDER_PTE 12
@@ -180,6 +189,9 @@
                                -1,     -1,     1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
                             /* 30/1G   31/2G */ \
                                -1,     -1 \
+/* PTE user modifiable flags */
+#define COS_PAGE_READABLE (0)
+#define COS_PAGE_WRITABLE (1ul << 1)
 
 #endif
 #endif /* COS_CONFIG_H */

--- a/src/platform/i386/chal_pgtbl.h
+++ b/src/platform/i386/chal_pgtbl.h
@@ -16,10 +16,23 @@ typedef enum {
 	X86_PGTBL_COSFRAME   = 1 << 9,
 	X86_PGTBL_COSKMEM    = 1 << 10, /* page activated as kernel object */
 	X86_PGTBL_QUIESCENCE = 1 << 11,
+#if defined(__x86_64__)
+	X86_PGTBL_PKEY0      = 1ul << 59, /* MPK key bits */
+	X86_PGTBL_PKEY1      = 1ul << 60, 
+	X86_PGTBL_PKEY2      = 1ul << 61, 
+	X86_PGTBL_PKEY3      = 1ul << 62, 
+
+	X86_PGTBL_XDISABLE   = 1ul << 63,
+#endif
 	/* Flag bits done. */
 
 	X86_PGTBL_USER_DEF   = X86_PGTBL_PRESENT | X86_PGTBL_USER | X86_PGTBL_ACCESSED | X86_PGTBL_MODIFIED | X86_PGTBL_WRITABLE,
 	X86_PGTBL_INTERN_DEF = X86_PGTBL_USER_DEF,
+#if defined(__x86_64__)
+	X86_PGTBL_USER_MODIFIABLE = X86_PGTBL_WRITABLE | X86_PGTBL_PKEY0 | X86_PGTBL_PKEY1 | X86_PGTBL_PKEY2 | X86_PGTBL_PKEY3 | X86_PGTBL_XDISABLE,
+#elif defined(__i386__)	
+	X86_PGTBL_USER_MODIFIABLE = X86_PGTBL_WRITABLE,
+#endif
 } pgtbl_flags_x86_t;
 
 /**
@@ -142,9 +155,9 @@ pgtbl_alloc(void *page)
 }
 
 static int
-pgtbl_intern_expand(pgtbl_t pt, unsigned long addr, void *pte, u32_t flags)
+pgtbl_intern_expand(pgtbl_t pt, unsigned long addr, void *pte, unsigned long flags)
 {
-	unsigned long accum = (unsigned long)flags;
+	unsigned long accum = flags;
 	int           ret;
 
 	/* NOTE: flags currently ignored. */


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Added flags parameter to PGTBL CAPTBL_OP_CPY to edit PTE flags to allow delegation of page access rights. I had to change quite a bit of `u32_t` to `word_t` in the CHAL code since 64bit paging on x86_64 uses some high qword bits in the PTE as flags. I think this is also a better design since the x86 CHAL supports both 32bit and 64bit execution modes, but I might be wrong so I am definitely looking for feedback on those edits.

### Intent for your PR

Choose one (Mandatory):

- [X] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)
@gparmer @WenyuanShao @betahxy

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [X] Comments adhere to the Style Guide (SG)
- [X] Spacing adhere's to the SG
- [X] Naming adhere's to the SG
- [X] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [X] I've made an attempt to remove all redundant code
- [X] I've considered ways in which my changes might impact existing code, and cleaned it up
- [X] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [X] I've commented appropriately where code is tricky
- [X] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [X] unit_pingpong
- [X] unit_schedtests
- [x] ...sched_ping_pong, sched_crt_tests
