### PR TITLE
VAS bug fix

### DIFF
--- a/src/components/lib/crt/crt.c
+++ b/src/components/lib/crt/crt.c
@@ -355,6 +355,8 @@ crt_comp_create_in_vas(struct crt_comp *c, char *name, compid_t id, void *elf_hd
 static int
 crt_ns_vas_shared(struct crt_comp *c1, struct crt_comp *c2)
 {
+	if(c1->ns_vas == NULL || c2->ns_vas == NULL) return 0;
+
 	if (c1->ns_vas == c2->ns_vas) return 1;
 
 	return 0;
@@ -754,8 +756,9 @@ crt_sinv_create(struct crt_sinv *sinv, char *name, struct crt_comp *server, stru
 		.s_fn_addr   = s_fn_addr
 	};
 
-	if (crt_ns_vas_shared(client, server)) 
+	if (crt_ns_vas_shared(client, server)) {
 		sinv->sinv_cap = cos_sinv_alloc(cli, srv->comp_cap_shared, sinv->s_fn_addr, client->id);
+	}
 	else 
 		sinv->sinv_cap = cos_sinv_alloc(cli, srv->comp_cap, sinv->s_fn_addr, client->id);
 

--- a/src/components/lib/crt/crt.c
+++ b/src/components/lib/crt/crt.c
@@ -355,7 +355,7 @@ crt_comp_create_in_vas(struct crt_comp *c, char *name, compid_t id, void *elf_hd
 static int
 crt_ns_vas_shared(struct crt_comp *c1, struct crt_comp *c2)
 {
-	if(c1->ns_vas == NULL || c2->ns_vas == NULL) return 0;
+	if (c1->ns_vas == NULL || c2->ns_vas == NULL) return 0;
 
 	if (c1->ns_vas == c2->ns_vas) return 1;
 
@@ -756,9 +756,8 @@ crt_sinv_create(struct crt_sinv *sinv, char *name, struct crt_comp *server, stru
 		.s_fn_addr   = s_fn_addr
 	};
 
-	if (crt_ns_vas_shared(client, server)) {
+	if (crt_ns_vas_shared(client, server))
 		sinv->sinv_cap = cos_sinv_alloc(cli, srv->comp_cap_shared, sinv->s_fn_addr, client->id);
-	}
 	else 
 		sinv->sinv_cap = cos_sinv_alloc(cli, srv->comp_cap, sinv->s_fn_addr, client->id);
 


### PR DESCRIPTION
### Summary of this Pull Request (PR)

**Fix bug with `crt_ns_vas_shared` that didn't check if two components have a null VAS NS pointer.**

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer  @WenyuanShao 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [x] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [x] unit_pingpong
- [x] unit_schedtests
- [ ] ...(add others here)
