### PR TITLE
Simple TCP echo server component  + LWIP component + DPDK component implementation, for discussion

### DIFF
--- a/composition_scripts/net.toml
+++ b/composition_scripts/net.toml
@@ -1,0 +1,37 @@
+[system]
+description = "Simple DPDK component: test if it can drive NIC and sent/receive packets"
+
+[[components]]
+name = "booter"
+img  = "no_interface.llbooter"
+implements = [{interface = "init"}, {interface = "addr"}]
+deps = [{srv = "kernel", interface = "init", variant = "kernel"}]
+constructor = "kernel"
+
+[[components]]
+name = "capmgr"
+img  = "capmgr.simple"
+deps = [{srv = "booter", interface = "init"}, {srv = "booter", interface = "addr"}]
+implements = [{interface = "capmgr"}, {interface = "init"}, {interface = "memmgr"}, {interface = "capmgr_create"}, {interface = "contigmem"}]
+constructor = "booter"
+
+[[components]]
+name = "sched"
+img  = "sched.root_fprr"
+deps = [{srv = "capmgr", interface = "init"}, {srv = "capmgr", interface = "capmgr"}, {srv = "capmgr", interface = "memmgr"}]
+implements = [{interface = "sched"}, {interface = "init"}]
+constructor = "booter"
+
+[[components]]
+name = "nicmgr"
+img  = "nicmgr.dpdk"
+deps = [{srv = "sched", interface = "sched"}, {srv = "sched", interface = "init"}, {srv = "capmgr", interface = "capmgr_create"}, {srv = "capmgr", interface = "memmgr"}, {srv = "capmgr", interface = "contigmem"}]
+implements = [{interface = "nic"}, {interface = "netshmem"}]
+baseaddr = "0x1600000"
+constructor = "booter"
+
+[[components]]
+name = "netmgr"
+img  = "netmgr.lwip"
+deps = [{srv = "sched", interface = "sched"}, {srv = "sched", interface = "init"}, {srv = "capmgr", interface = "capmgr_create"}, {srv = "capmgr", interface = "memmgr"}, {srv = "capmgr", interface = "contigmem"}, {srv = "nicmgr", interface = "nic"}, {srv = "nicmgr", interface = "netshmem"}]
+constructor = "booter"

--- a/composition_scripts/simple_tcp_server.toml
+++ b/composition_scripts/simple_tcp_server.toml
@@ -1,0 +1,44 @@
+[system]
+description = "Simple DPDK component: test if it can drive NIC and sent/receive packets"
+
+[[components]]
+name = "booter"
+img  = "no_interface.llbooter"
+implements = [{interface = "init"}, {interface = "addr"}]
+deps = [{srv = "kernel", interface = "init", variant = "kernel"}]
+constructor = "kernel"
+
+[[components]]
+name = "capmgr"
+img  = "capmgr.simple"
+deps = [{srv = "booter", interface = "init"}, {srv = "booter", interface = "addr"}]
+implements = [{interface = "capmgr"}, {interface = "init"}, {interface = "memmgr"}, {interface = "capmgr_create"}, {interface = "contigmem"}]
+constructor = "booter"
+
+[[components]]
+name = "sched"
+img  = "sched.root_fprr"
+deps = [{srv = "capmgr", interface = "init"}, {srv = "capmgr", interface = "capmgr"}, {srv = "capmgr", interface = "memmgr"}]
+implements = [{interface = "sched"}, {interface = "init"}]
+constructor = "booter"
+
+[[components]]
+name = "nicmgr"
+img  = "nicmgr.dpdk"
+deps = [{srv = "sched", interface = "sched"}, {srv = "sched", interface = "init"}, {srv = "capmgr", interface = "capmgr_create"}, {srv = "capmgr", interface = "memmgr"}, {srv = "capmgr", interface = "contigmem"}]
+implements = [{interface = "nic"}]
+baseaddr = "0x1600000"
+constructor = "booter"
+
+[[components]]
+name = "netmgr"
+img  = "netmgr.lwip"
+deps = [{srv = "sched", interface = "sched"}, {srv = "sched", interface = "init"}, {srv = "capmgr", interface = "capmgr_create"}, {srv = "capmgr", interface = "memmgr"}, {srv = "capmgr", interface = "contigmem"}, {srv = "nicmgr", interface = "nic"}]
+implements = [{interface = "netmgr"}]
+constructor = "booter"
+
+[[components]]
+name = "simple_tcp_server"
+img  = "simple_tcp_server.simple_tcp_server"
+deps = [{srv = "sched", interface = "sched"}, {srv = "sched", interface = "init"},{srv = "capmgr", interface = "capmgr_create"}, {srv = "capmgr", interface = "memmgr"}, {srv = "capmgr", interface = "contigmem"}, {srv = "netmgr", interface = "netmgr"}]
+constructor = "booter"

--- a/src/components/implementation/capmgr/simple/Makefile
+++ b/src/components/implementation/capmgr/simple/Makefile
@@ -3,7 +3,7 @@
 #
 # The set of interfaces that this component exports for use by other
 # components. This is a list of the interface names.
-INTERFACE_EXPORTS = capmgr capmgr_create init
+INTERFACE_EXPORTS = capmgr capmgr_create init contigmem
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
 INTERFACE_DEPENDENCIES = init addr

--- a/src/components/implementation/capmgr/simple/capmgr.c
+++ b/src/components/implementation/capmgr/simple/capmgr.c
@@ -16,6 +16,7 @@
 #include <sl.h>
 #include <initargs.h>
 #include <addr.h>
+#include <contigmem.h>
 
 struct cm_rcv {
 	struct crt_rcv rcv;
@@ -210,6 +211,122 @@ mm_page_allocn(struct cm_comp *c, unsigned long num_pages, unsigned long align)
 }
 
 vaddr_t
+memmgr_virt_to_phys(vaddr_t vaddr)
+{
+	struct cm_comp *c;
+
+	c = ss_comp_get(cos_inv_token());
+	if (!c) return 0;
+	
+	return call_cap_op(c->comp.comp_res->ci.pgtbl_cap, CAPTBL_OP_INTROSPECT, (vaddr_t)vaddr, 0, 0, 0);
+}
+
+void
+check_contigmem(vaddr_t vaddr, int npages)
+{
+	u64_t paddr_pre = 0, paddr_next = 0;
+
+	paddr_pre = memmgr_virt_to_phys(vaddr);
+
+	for(int i = 1;i < npages; i++) {
+		paddr_next = memmgr_virt_to_phys(vaddr + i * PAGE_SIZE);
+		assert(paddr_next - paddr_pre == PAGE_SIZE);
+
+		paddr_pre = paddr_next;
+	}
+}
+
+vaddr_t
+contigmem_alloc(unsigned long npages)
+{
+	struct cm_comp *c;
+	struct mm_page *p;
+	struct mm_mapping *m;
+	vaddr_t     vaddr;
+	unsigned long i;
+
+	c = ss_comp_get(cos_inv_token());
+	if (!c) return 0;
+
+	void *page = crt_page_allocn(&cm_self()->comp, npages);
+	assert(page);
+
+	if (crt_page_aliasn_aligned_in(page, PAGE_SIZE, npages, &cm_self()->comp, &c->comp, &vaddr)) BUG();
+
+	for (i = 0; i < npages; i++) {
+		p = ss_page_alloc();
+		assert(p);
+
+		m = &p->mappings[0];
+		if (ss_state_alloc(&m->comp)) BUG();
+
+		p->page = page + i * PAGE_SIZE;
+		m->addr = vaddr + i * PAGE_SIZE;
+
+		ss_state_activate_with(&m->comp, (word_t)c);
+		ss_page_activate(p);
+	}
+
+	check_contigmem((vaddr_t)vaddr, npages);
+	return vaddr;
+}
+
+cbuf_t
+contigmem_shared_alloc_aligned(unsigned long npages, unsigned long align, vaddr_t *pgaddr)
+{
+	struct cm_comp *c;
+	struct mm_page *p, *initial = NULL;
+	struct mm_mapping *m;
+	struct mm_span *s;
+	vaddr_t     vaddr;
+	unsigned long i;
+	int ret;
+
+	c = ss_comp_get(cos_inv_token());
+	if (!c) return 0;
+
+	void *page = crt_page_allocn(&cm_self()->comp, npages);
+	assert(page);
+
+	if (crt_page_aliasn_aligned_in(page, align, npages, &cm_self()->comp, &c->comp, &vaddr)) BUG();
+
+	s = ss_span_alloc();
+	if (!s) return 0;
+	for (i = 0; i < npages; i++) {
+		p = ss_page_alloc();
+		assert(p);
+
+		if (unlikely(i == 0)) {
+			initial = p;
+		}
+
+		m = &p->mappings[0];
+		if (ss_state_alloc(&m->comp)) BUG();
+
+		p->page = page + i * PAGE_SIZE;
+		m->addr = vaddr + i * PAGE_SIZE;
+
+		ss_state_activate_with(&m->comp, (word_t)c);
+		ss_page_activate(p);
+	}
+
+	/**
+	 * FIXME: Need to reslove concurrent issue here,
+	 * this is not multi-thread safe
+	 */
+	s->page_off = ss_page_id(initial);
+	s->n_pages  = npages;
+	ss_span_activate(s);
+
+	ret = ss_span_id(s);
+
+	*pgaddr = initial->mappings[0].addr;
+
+	check_contigmem((vaddr_t)vaddr, npages);
+	return ret;
+}
+
+vaddr_t
 memmgr_heap_page_allocn_aligned(unsigned long num_pages, unsigned long align)
 {
 	struct cm_comp *c;
@@ -221,17 +338,6 @@ memmgr_heap_page_allocn_aligned(unsigned long num_pages, unsigned long align)
 	if (!p) return 0;
 
 	return (vaddr_t)p->mappings[0].addr;
-}
-
-vaddr_t
-memmgr_virt_to_phys(vaddr_t vaddr)
-{
-	struct cm_comp *c;
-
-	c = ss_comp_get(cos_inv_token());
-	if (!c) return 0;
-	
-	return call_cap_op(c->comp.comp_res->ci.pgtbl_cap, CAPTBL_OP_INTROSPECT, (vaddr_t)vaddr, 0, 0, 0);
 }
 
 vaddr_t

--- a/src/components/implementation/netmgr/Makefile
+++ b/src/components/implementation/netmgr/Makefile
@@ -3,16 +3,16 @@
 #
 # The set of interfaces that this component exports for use by other
 # components. This is a list of the interface names.
-INTERFACE_EXPORTS = nic 
+INTERFACE_EXPORTS = 
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
-INTERFACE_DEPENDENCIES = netshmem
+INTERFACE_DEPENDENCIES = 
 # The library dependencies this component is reliant on for
 # compilation/linking (this is a list of directory names in lib/)
-LIBRARY_DEPENDENCIES = component dpdk shm_bm ck
+LIBRARY_DEPENDENCIES = component 
 # Note: Both the interface and library dependencies should be
 # *minimal*. That is to say that removing a dependency should cause
 # the build to fail. The build system does not validate this
 # minimality; that's on you!
 
-include Makefile.subsubdir
+include Makefile.subdir

--- a/src/components/implementation/netmgr/lwip/Makefile
+++ b/src/components/implementation/netmgr/lwip/Makefile
@@ -3,13 +3,13 @@
 #
 # The set of interfaces that this component exports for use by other
 # components. This is a list of the interface names.
-INTERFACE_EXPORTS = nic 
+INTERFACE_EXPORTS = netmgr
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
-INTERFACE_DEPENDENCIES = netshmem
+INTERFACE_DEPENDENCIES = memmgr netshmem nic contigmem netshmem
 # The library dependencies this component is reliant on for
 # compilation/linking (this is a list of directory names in lib/)
-LIBRARY_DEPENDENCIES = component dpdk shm_bm ck
+LIBRARY_DEPENDENCIES = component shm_bm lwip
 # Note: Both the interface and library dependencies should be
 # *minimal*. That is to say that removing a dependency should cause
 # the build to fail. The build system does not validate this

--- a/src/components/implementation/netmgr/lwip/init.c
+++ b/src/components/implementation/netmgr/lwip/init.c
@@ -46,7 +46,6 @@ cos_interface_output(struct netif *ni, struct pbuf *p, const ip4_addr_t *ip)
 			obj = (struct netshmem_pkt_buf*)(p->next->payload - NETSHMEM_HEADROOM);
 			objid = obj->objid;
 			data = obj->payload_offset + obj->data;
-			// printc("before dpdk:%s\n", data);
 			memcpy(data - p->len, p->payload, p->len);
 			obj->payload_offset = obj->payload_offset - p->len;
 			obj->payload_sz += p->len;
@@ -57,9 +56,6 @@ cos_interface_output(struct netif *ni, struct pbuf *p, const ip4_addr_t *ip)
 			if (obj == NULL) return ERR_OK;
 
 			memcpy(obj->data, data, p->len);
-			// for(int i = 0;i < p->len;i++) {
-			// 	obj->data[i] = data[i];
-			// }
 			obj->payload_offset = 0;
 			obj->payload_sz = p->len;
 

--- a/src/components/implementation/netmgr/lwip/init.c
+++ b/src/components/implementation/netmgr/lwip/init.c
@@ -1,0 +1,144 @@
+
+#include <cos_types.h>
+#include <netshmem.h>
+#include <shm_bm.h>
+#include <string.h>
+#include <nic.h>
+#include <contigmem.h>
+
+#include <lwip/init.h>
+#include <lwip/netif.h>
+#include <lwip/tcp.h>
+#include <lwip/stats.h>
+#include <lwip/prot/tcp.h>
+#include <netif/ethernet.h>
+#include <lwip/etharp.h>
+
+static struct ip4_addr ip, mask, gw, client;
+struct netif net_interface;
+
+struct ether_addr {
+	uint8_t addr_bytes[6];
+} __attribute__((__packed__));
+
+struct ether_hdr {
+	struct ether_addr dst_addr;
+	struct ether_addr src_addr;
+	uint16_t ether_type;
+} __attribute__((__packed__));
+
+
+
+shm_bm_t shm;
+shm_bm_objid_t  objid;
+
+static err_t
+cos_interface_output(struct netif *ni, struct pbuf *p, const ip4_addr_t *ip)
+{
+	char * data = p->payload;
+	shm_bm_objid_t  objid;
+	struct netshmem_pkt_buf *obj;
+
+	// printc("hhhhhhhhhhhhhhhh\n");
+	if (p->type_internal & PBUF_RAM) {
+		if(p->next != NULL && p->next->type_internal & PBUF_ROM) {
+			/* shemem case, pbuf is chained with a header pbuf and a data pbuf that points to shemem */
+			obj = (struct netshmem_pkt_buf*)(p->next->payload - NETSHMEM_HEADROOM);
+			objid = obj->objid;
+			data = obj->payload_offset + obj->data;
+			// printc("before dpdk:%s\n", data);
+			memcpy(data - p->len, p->payload, p->len);
+			obj->payload_offset = obj->payload_offset - p->len;
+			obj->payload_sz += p->len;
+			nic_send_packet(objid, obj->payload_sz);
+		} else {
+			/* other cases that don't use shmem */
+			obj = shm_bm_alloc_tx_pkt_buf(netshmem_get_tx_shm(), &objid);
+			if (obj == NULL) return ERR_OK;
+
+			memcpy(obj->data, data, p->len);
+			// for(int i = 0;i < p->len;i++) {
+			// 	obj->data[i] = data[i];
+			// }
+			obj->payload_offset = 0;
+			obj->payload_sz = p->len;
+
+			nic_send_packet(objid, obj->payload_sz);
+			shm_bm_free_tx_pkt_buf(obj);
+		}
+	}
+	return ERR_OK;
+}
+
+static err_t
+cos_interface_init(struct netif *ni)
+{
+	ni->name[0] = 'u';
+	ni->name[1] = 's';
+	ni->mtu     = 1500;
+	ni->output  = etharp_output;
+
+	ni->linkoutput = cos_interface_output;
+
+	ni->flags |= NETIF_FLAG_ETHARP;
+	ni->flags |= NETIF_FLAG_ETHERNET;
+
+	ni->hwaddr[0] = 0x66;
+	ni->hwaddr[1] = 0x66;
+	ni->hwaddr[2] = 0x66;
+	ni->hwaddr[3] = 0x66;
+	ni->hwaddr[4] = 0x66;
+	ni->hwaddr[5] = 0x66;
+	ni->hwaddr_len = ETH_HWADDR_LEN;
+
+	return ERR_OK;
+}
+
+
+
+void
+cos_init(void)
+{
+	void  *mem;
+	cbuf_t id;
+	size_t shmsz;
+
+
+	printc("netmgr init...\n");
+
+	IP4_ADDR(&ip, 10,10,1,2);
+	IP4_ADDR(&mask, 255,255,255,0);
+	IP4_ADDR(&gw, 10,10,1,10);
+	IP4_ADDR(&client, 10,10,1,2);
+
+
+
+	lwip_init();
+	netif_add(&net_interface, &ip, &mask, &gw, NULL, cos_interface_init, ethernet_input);
+	netif_set_default(&net_interface);
+	netif_set_up(&net_interface);
+	printc("netmgr init done\n");
+	// ip4_addr_t ipaddr;
+	// struct eth_addr ethaddr;
+	// ethaddr.addr[0] = 0x11;
+	// ethaddr.addr[1] = 0x11;
+	// ethaddr.addr[2] = 0x11;
+	// ethaddr.addr[3] = 0x11;
+	// ethaddr.addr[4] = 0x11;
+	// ethaddr.addr[5] = 0x11;
+	// etharp_add_static_entry(&client, &ethaddr);
+}
+
+
+int
+main(void)
+{
+	printc("netmgr main started\n");
+
+	while (1)
+	{
+
+	}
+
+	return 0;
+}

--- a/src/components/implementation/netmgr/lwip/init.c
+++ b/src/components/implementation/netmgr/lwip/init.c
@@ -39,7 +39,6 @@ cos_interface_output(struct netif *ni, struct pbuf *p, const ip4_addr_t *ip)
 	shm_bm_objid_t  objid;
 	struct netshmem_pkt_buf *obj;
 
-	// printc("hhhhhhhhhhhhhhhh\n");
 	if (p->type_internal & PBUF_RAM) {
 		if(p->next != NULL && p->next->type_internal & PBUF_ROM) {
 			/* shemem case, pbuf is chained with a header pbuf and a data pbuf that points to shemem */

--- a/src/components/implementation/netmgr/lwip/interface_impl.c
+++ b/src/components/implementation/netmgr/lwip/interface_impl.c
@@ -1,0 +1,232 @@
+#include <cos_types.h>
+#include <cos_component.h>
+#include <netshmem.h>
+#include <shm_bm.h>
+#include <string.h>
+#include <nic.h>
+#include <contigmem.h>
+
+#include <lwip/init.h>
+#include <lwip/netif.h>
+#include <lwip/tcp.h>
+#include <lwip/stats.h>
+#include <lwip/prot/tcp.h>
+#include <netif/ethernet.h>
+#include <lwip/etharp.h>
+
+#include <netmgr.h>
+
+int return_flag = 0;
+shm_bm_objid_t           g_objid;
+struct pbuf *g_pbuf = NULL;
+
+#define TCP_MAX_SERVER (16)
+
+extern struct netif net_interface;
+
+struct tcp_server
+{
+	struct tcp_pcb *tp;
+};
+
+struct tcp_server tcp_servers[TCP_MAX_SERVER];
+
+static err_t
+cos_lwip_tcp_sent(void *arg, struct tcp_pcb *tp, u16_t len)
+{
+	// printc("tcp sent\n");
+	return ERR_OK;
+}
+
+
+static err_t
+cos_lwip_tcp_recv(void *arg, struct tcp_pcb *tp, struct pbuf *p, err_t err)
+{
+	err_t ret_err;
+
+	if(p != NULL) {
+		return_flag = 1;
+		g_pbuf = p;
+		// tcp_recved(tp, p->tot_len);
+	}
+
+	return ERR_OK;
+
+}
+
+static void
+cos_lwip_tcp_err(void *arg,  err_t err)
+{
+	assert(0);
+	return;
+}
+
+static err_t
+cos_lwip_tcp_accept(void *arg, struct tcp_pcb *tp, err_t err)
+{
+	err_t ret_err;
+	compid_t client = (compid_t)cos_inv_token();
+
+	tcp_arg(tp, 0);
+	tcp_err(tp, cos_lwip_tcp_err);
+	tcp_recv(tp, cos_lwip_tcp_recv);
+	tcp_sent(tp, cos_lwip_tcp_sent);
+
+	tcp_servers[client].tp = tp;
+
+	tcp_nagle_disable(tp);
+
+	ret_err = ERR_OK;
+	return ret_err;
+}
+
+void netmgr_shmem_init(cbuf_t rx_shm_id, cbuf_t tx_shm_id)
+{
+	nic_shmem_init(rx_shm_id, tx_shm_id);
+	netshmem_map_shmem(rx_shm_id, tx_shm_id);
+}
+
+int
+netmgr_tcp_bind(u32_t ip_addr, u16_t port)
+{
+
+	unsigned long npages;
+	void         *mem;
+	shm_bm_t shm;
+	struct netshmem_pkt_buf *obj;
+
+	struct tcp_pcb *tp;
+	struct ip4_addr ipa = *(struct ip4_addr*)&ip_addr;
+	err_t ret;
+
+	compid_t client = (compid_t)cos_inv_token();
+	unsigned long paddr = 0;
+
+	nic_bind_port(ip_addr, htons(port));
+
+	tp = tcp_new();
+	assert(tp != NULL);
+
+	tcp_servers[client].tp = tp;
+
+	ret = tcp_bind(tp, &ipa, port);
+
+	return ret;
+}
+
+int
+netmgr_tcp_listen(u8_t backlog)
+{
+	struct tcp_pcb *new_tp = NULL;
+	compid_t client = (compid_t)cos_inv_token();
+
+	new_tp = tcp_listen_with_backlog(tcp_servers[client].tp, backlog);
+	assert(new_tp);
+
+	tcp_servers[client].tp = new_tp;
+
+	return ERR_OK;
+}
+
+static void
+net_interface_input(void * pkt, int len)
+{
+	void *pl;
+	struct pbuf *p;
+	
+	pl = pkt;
+
+	p = pbuf_alloc(PBUF_LINK, len, PBUF_ROM);
+
+	assert(p);
+
+	p->payload = pl;
+	if (net_interface.input(p, &net_interface) != ERR_OK) {
+		assert(0);
+	}
+
+	if (p->ref != 0) {
+		pbuf_free(p);
+	}
+
+	return;
+}
+
+int
+net_receive_packet(char* pkt, size_t pkt_len)
+{
+	net_interface_input(pkt, pkt_len);
+	return 0;
+}
+
+int
+netmgr_tcp_accept(struct conn_addr *client_addr)
+{
+	shm_bm_objid_t           objid;
+	struct netshmem_pkt_buf *obj;
+	size_t shmsz;
+	cbuf_t rx_shm_id;
+	void  *mem;
+
+	compid_t client = (compid_t)cos_inv_token();
+
+	netif_set_link_up(&net_interface);
+	tcp_accept(tcp_servers[client].tp, cos_lwip_tcp_accept);
+
+	// should block here
+	while (!return_flag)
+	{
+		objid = nic_get_a_packet();
+		obj = shm_bm_take_rx_pkt_buf(netshmem_get_rx_shm(), objid);
+
+		net_receive_packet(obj->payload_offset + obj->data, obj->payload_sz);
+		
+	}
+	g_objid = objid;
+	obj->payload_offset = (char*)g_pbuf->payload - obj->data;
+	obj->payload_sz = g_pbuf->len;
+
+	return 0;
+}
+
+shm_bm_objid_t
+netmgr_tcp_shmem_read(void)
+{
+	shm_bm_objid_t           objid;
+	struct netshmem_pkt_buf *obj;
+
+	while (!return_flag)
+	{
+		objid = nic_get_a_packet();
+		obj = shm_bm_take_rx_pkt_buf(netshmem_get_rx_shm(), objid);
+
+		net_receive_packet(obj->payload_offset + obj->data, obj->payload_sz);
+		obj->payload_offset = (char*)g_pbuf->payload - obj->data;
+		obj->payload_sz = g_pbuf->len;
+		g_objid = objid;
+	}
+
+	return_flag = 0;
+	return g_objid;
+}
+
+int
+netmgr_tcp_shmem_write(shm_bm_objid_t objid)
+{
+	struct netshmem_pkt_buf *obj;
+
+	compid_t client = (compid_t)cos_inv_token();
+	char *data;
+
+	obj = shm_bm_take_tx_pkt_buf(netshmem_get_tx_shm(), objid);
+	obj->objid = objid;
+	data = obj->data + obj->payload_offset;
+
+	err_t wr_err = tcp_write(tcp_servers[client].tp, data, obj->payload_sz, 0);
+	assert(wr_err == ERR_OK);
+
+	// wr_err = tcp_output(tcp_servers[client].tp);
+	// assert(wr_err == ERR_OK);
+
+	return 0;
+}

--- a/src/components/implementation/nicmgr/dpdk/init.c
+++ b/src/components/implementation/nicmgr/dpdk/init.c
@@ -1,20 +1,187 @@
 #include <llprint.h>
 #include <cos_dpdk.h>
 #include <nic.h>
+#include <shm_bm.h>
+#include <netshmem.h>
+#include <sched.h>
+#include <arpa/inet.h>
+
+#include "interface_impl.h"
 
 #define NB_RX_DESC_DEFAULT 1024
 #define NB_TX_DESC_DEFAULT 1024
+
 #define MAX_PKT_BURST 512
+
+#define NIPQUAD(addr) \
+((unsigned char *)&addr)[0], \
+((unsigned char *)&addr)[1], \
+((unsigned char *)&addr)[2], \
+((unsigned char *)&addr)[3]
+#define NIPQUAD_FMT "%u.%u.%u.%u"
+
+struct eth_hdr {
+	u8_t dst_addr[6];
+	u8_t src_addr[6];
+	u16_t ether_type;
+} __attribute__((packed));
+
+struct ether_addr {
+	uint8_t addr_bytes[6]; /**< Addr bytes in tx order */
+} __attribute__((packed));
+
+struct arp_ipv4 {
+	struct ether_addr arp_sha;  /**< sender hardware address */
+	uint32_t          arp_sip;  /**< sender IP address */
+	struct ether_addr arp_tha;  /**< target hardware address */
+	uint32_t          arp_tip;  /**< target IP address */
+} __attribute__((packed));
+
+struct arp_hdr {
+	uint16_t arp_hardware;    /* format of hardware address */
+#define RTE_ARP_HRD_ETHER     1  /* ARP Ethernet address format */
+
+	uint16_t arp_protocol;    /* format of protocol address */
+	uint8_t  arp_hlen;    /* length of hardware address */
+	uint8_t  arp_plen;    /* length of protocol address */
+	uint16_t arp_opcode;     /* ARP opcode (command) */
+#define	RTE_ARP_OP_REQUEST    1 /* request to resolve address */
+#define	RTE_ARP_OP_REPLY      2 /* response to previous request */
+#define	RTE_ARP_OP_REVREQUEST 3 /* request proto addr given hardware */
+#define	RTE_ARP_OP_REVREPLY   4 /* response giving protocol address */
+#define	RTE_ARP_OP_INVREQUEST 8 /* request to identify peer */
+#define	RTE_ARP_OP_INVREPLY   9 /* response identifying peer */
+
+	struct arp_ipv4 arp_data;
+} __attribute__((packed));
+
+struct ip_hdr {
+	u8_t ihl:4;
+	u8_t version:4;
+	u8_t tos;
+	u16_t total_len;
+	u16_t id;
+	u16_t frag_off;
+	u8_t ttl;
+	u8_t proto;
+	u16_t checksum;
+	u32_t src_addr;
+	u32_t dst_addr;
+} __attribute__((packed));
+
+struct tcp_udp_port
+{
+	u16_t src_port;
+	u16_t dst_port;
+};
+
+char* g_rx_mp = NULL;
+char* g_tx_mp = NULL;
 
 static u16_t nic_ports = 0;
 
 static void
-process_packets(cos_portid_t port_id, char** rx_pkts, uint16_t nb_pkts)
+tx_ringbuf_init()
+{
+	vaddr_t buf_addr = NULL;
+
+	buf_addr = malloc(TX_PKT_RING_SZ);
+	assert(buf_addr);
+
+	ck_ring_init(buf_addr, TX_PKT_RBUF_SZ);
+
+	g_tx_ring    = buf_addr;
+	g_tx_ringbuf = buf_addr + sizeof(struct ck_ring);
+}
+
+static struct client_session *
+find_session(uint32_t dst_ip, uint16_t dst_port)
 {
 	int i;
+	for (i = 0; i < NIC_MAX_SESSION; i++) {
+		if (client_sessions[i].ip_addr == dst_ip /*&& client_sessions[i].port == dst_port*/) {
+			return &client_sessions[i];
+		} 
+	}
+
+	return NULL;
+}
+
+static void
+ext_buf_free_callback_fn(void *addr, void *opaque)
+{
+	bool *freed = opaque;
+
+	if (addr == NULL) {
+		printc("External buffer address is invalid\n");
+		return;
+	}
+
+	*freed = true;
+	// printc("External buffer freed via callback\n");
+}
+
+static void
+process_tx_packets(void)
+{
+	struct pkt_buf buf;
+	char* mbuf;
+
+	while (!tx_pkt_ring_buf_empty(g_tx_ring))
+	{
+		tx_pkt_ring_buf_dequeue(g_tx_ring, g_tx_ringbuf, &buf);
+
+		mbuf = cos_allocate_mbuf(g_tx_mp);
+		cos_attach_external_mbuf(mbuf, buf.pkt, PKT_BUF_SIZE, ext_buf_free_callback_fn, buf.paddr);
+		cos_send_external_packet(mbuf, buf.pkt_len);
+
+		cos_free_packet(mbuf);
+	}
+}
+
+static void
+process_rx_packets(cos_portid_t port_id, char** rx_pkts, uint16_t nb_pkts)
+{
+	int i;
+	int len = 0;
+
+	struct eth_hdr      *eth;
+	struct ip_hdr       *iph;
+	struct arp_hdr      *arp_hdr;
+	struct tcp_udp_port *port;
+	struct client_session * session;
+	struct pkt_buf buf;
 
 	for (i = 0; i < nb_pkts; i++) {
-		char * pkt = cos_get_packet(rx_pkts[i]);
+		char * pkt = cos_get_packet(rx_pkts[i], &len);
+		eth = pkt;
+		if (htons(eth->ether_type) == 0x0800) {
+			iph = (char*)eth + sizeof(struct eth_hdr);
+			port = (char*)eth + sizeof(struct eth_hdr) + iph->ihl * 4;
+
+			session = find_session(iph->dst_addr, port->dst_port);
+			if(session == NULL) {
+				continue;
+			}
+			buf.pkt = rx_pkts[i];
+			rx_pkt_ring_buf_enqueue(session, &buf);
+			
+			sched_thd_wakeup(session->thd);
+		} else if (htons(eth->ether_type) == 0x0806) {
+			arp_hdr = (char*)eth + sizeof(struct eth_hdr);
+			session = find_session(arp_hdr->arp_data.arp_tip, 0);
+			if(session == NULL) {
+				continue;
+			}
+			buf.pkt = rx_pkts[i];
+			rx_pkt_ring_buf_enqueue(session, &buf);
+			
+			sched_thd_wakeup(session->thd);
+		} else {
+
+			continue;
+		}
+
 	}
 }
 
@@ -31,14 +198,14 @@ cos_nic_start(){
 		for (i = 0; i < nic_ports; i++) {
 			/* process rx */
 			nb_pkts = cos_dev_port_rx_burst(i, 0, rx_packets, MAX_PKT_BURST);
-			if (nb_pkts != 0) {
-				process_packets(i, rx_packets, nb_pkts);
-			}
+
+			if (nb_pkts != 0) process_rx_packets(i, rx_packets, nb_pkts);
+
+			process_tx_packets();
 		}
 	}
 }
 
-static char* g_mp = NULL;
 static void
 cos_nic_init(void)
 {
@@ -46,7 +213,8 @@ cos_nic_init(void)
 
 	#define MAX_PKT_BURST 512
 
-	const char *mpool_name = "cos_app_pool";
+	const char *rx_mpool_name = "cos_app_rx_pool";
+	const char *tx_mpool_name = "cos_app_tx_pool";
 	uint16_t i;
 	uint16_t nb_rx_desc = NB_RX_DESC_DEFAULT;
 	uint16_t nb_tx_desc = NB_TX_DESC_DEFAULT;
@@ -55,7 +223,7 @@ cos_nic_init(void)
 	 * set max_mbufs 2 times than nb_rx_desc, so that there is enough room
 	 * to store packets, or this will fail if nb_rx_desc <= max_mbufs.
 	 */
-	const size_t max_mbufs = 8 * nb_rx_desc;
+	const size_t max_mbufs = 2 * nb_rx_desc;
 
 	char *argv[] =	{
 			"COS_DPDK_BOOTER", /* single core, the first argument has to be the program name */
@@ -67,7 +235,7 @@ cos_nic_init(void)
 			"--log-level",
 			"*:info", /* log level can be changed to *debug* if needed, this will print lots of information */
 			"-m",
-			"64", /* total memory used by dpdk memory subsystem, such as mempool */
+			"128", /* total memory used by dpdk memory subsystem, such as mempool */
 			};
 
 	argc = ARRAY_SIZE(argv);
@@ -83,10 +251,12 @@ cos_nic_init(void)
 	assert(nic_ports > 0);
 
 	/* 3. create mbuf pool where packets will be stored, user can create multiple pools */
-	char* mp = cos_create_pkt_mbuf_pool(mpool_name, max_mbufs);
-	g_mp = mp;
-
+	char* mp = cos_create_pkt_mbuf_pool(rx_mpool_name, max_mbufs);
 	assert(mp != NULL);
+	g_rx_mp = mp;
+
+	g_tx_mp = cos_create_pkt_mbuf_pool(tx_mpool_name, max_mbufs);
+	assert(g_tx_mp);
 
 	/* 4. config each port */
 	for (i = 0; i < nic_ports; i++) {
@@ -103,25 +273,12 @@ cos_nic_init(void)
 	}
 }
 
-int
-nic_send_packet(char* pkt, size_t pkt_size)
-{
-	/* TODO: implement this interface */
-	return 0;
-}
-
-int
-nic_bind_port(u32_t ip_addr, u16_t port, void* share_mem, size_t share_mem_sz)
-{
-	/* TODO: implement this interface */
-	return 0;
-}
-
 void
 cos_init(void)
 {
 	printc("nicmgr init...\n");
 	cos_nic_init();
+	tx_ringbuf_init();
 }
 
 int
@@ -130,6 +287,5 @@ main(void)
 	printc("NIC started\n");
 
 	cos_nic_start();
-
 	return 0;
 }

--- a/src/components/implementation/nicmgr/dpdk/interface_impl.c
+++ b/src/components/implementation/nicmgr/dpdk/interface_impl.c
@@ -1,0 +1,203 @@
+#include <cos_types.h>
+#include <memmgr.h>
+#include <netshmem.h>
+#include <shm_bm.h>
+#include <string.h>
+#include <sched.h>
+#include <nic.h>
+#include <cos_dpdk.h>
+#include <ck_ring.h>
+#include "interface_impl.h"
+
+typedef unsigned long cos_paddr_t; /* physical address */
+typedef unsigned long cos_vaddr_t; /* virtual address */
+
+extern cos_paddr_t cos_map_virt_to_phys(cos_vaddr_t addr);
+extern char* g_tx_mp;
+extern char* g_rx_mp;
+
+/* indexed by thread id */
+struct client_session client_sessions[NIC_MAX_SESSION];
+
+CK_RING_PROTOTYPE(rx_pkt_ring_buf, pkt_buf);
+CK_RING_PROTOTYPE(tx_pkt_ring_buf, pkt_buf);
+
+struct ck_ring *g_tx_ring = NULL;
+struct pkt_buf *g_tx_ringbuf = NULL;
+
+int
+rx_pkt_ring_buf_enqueue(struct client_session *session, struct pkt_buf *buf)
+{
+
+	if (!session->ring) return -1;
+	assert(session->ringbuf);
+
+	if (ck_ring_enqueue_spsc_rx_pkt_ring_buf(session->ring, session->ringbuf, buf) == false) return -1;
+
+	return 0;
+}
+
+int
+rx_pkt_ring_buf_dequeue(struct client_session *session, struct pkt_buf *buf)
+{
+	assert(buf);
+	if (!session->ring || !session->ringbuf) return 0;
+
+	if (ck_ring_dequeue_spsc_rx_pkt_ring_buf(session->ring, session->ringbuf, buf) == true) return 1;
+
+	return 0;
+}
+
+int
+rx_pkt_ring_buf_empty(struct client_session *session)
+{
+	struct ck_ring *cring = session->ring;
+
+	if (!cring) return 1;
+
+	return (!ck_ring_size(cring));
+}
+
+int
+tx_pkt_ring_buf_enqueue(struct ck_ring *tx_ring, struct pkt_buf *tx_ringbuf, struct pkt_buf *buf)
+{
+	assert(tx_ring && tx_ringbuf);
+
+	if (ck_ring_enqueue_spsc_rx_pkt_ring_buf(tx_ring, tx_ringbuf, buf) == false) return -1;
+
+	return 0;
+}
+
+int
+tx_pkt_ring_buf_dequeue(struct ck_ring *tx_ring, struct pkt_buf *tx_ringbuf, struct pkt_buf *buf)
+{
+	assert(tx_ring && tx_ringbuf);
+
+	if (ck_ring_dequeue_spsc_tx_pkt_ring_buf(tx_ring, tx_ringbuf, buf) == true) return 1;
+
+	return 0;
+}
+
+int
+tx_pkt_ring_buf_empty(struct ck_ring *tx_ring)
+{
+	return (!ck_ring_size(tx_ring));
+}
+
+shm_bm_objid_t
+nic_get_a_packet()
+{
+	thdid_t                thd;
+	struct client_session *session;
+	struct pkt_buf         buf;
+	shm_bm_objid_t         objid;
+	struct netshmem_pkt_buf    *obj;
+	int i, len;
+
+	thd = cos_thdid();
+	assert(thd < NIC_MAX_SESSION);
+
+	session = &client_sessions[thd];
+	while (rx_pkt_ring_buf_empty(session)) {
+		sched_thd_block(0);
+	}
+
+	rx_pkt_ring_buf_dequeue(session, &buf);
+
+	obj = shm_bm_alloc_rx_pkt_buf(session->shemem_info[NIC_SHMEM_RX].shm, &objid);
+	char * pkt = cos_get_packet(buf.pkt, &len);
+	assert(len < PKT_BUF_SIZE);
+
+	for (i = 0; i < len; i++) {
+		obj->data[i] = pkt[i];
+	}
+
+	obj->payload_offset = 0;
+	obj->payload_sz = len;
+	return objid;
+}
+
+int
+nic_send_packet(shm_bm_objid_t pktid, u16_t pkt_len)
+{
+	thdid_t thd;
+	shm_bm_objid_t   objid;
+	struct netshmem_pkt_buf *obj;
+	struct pkt_buf buf;
+
+	thd = cos_thdid();
+	objid = pktid;
+
+	obj = (struct netshmem_pkt_buf*)shm_bm_take_tx_pkt_buf(client_sessions[thd].shemem_info[NIC_SHMEM_TX].shm, objid);
+
+	buf.pkt = obj->payload_offset + obj->data;
+
+	u64_t data_paddr = client_sessions[thd].shemem_info[NIC_SHMEM_TX].paddr 
+		+ (u64_t)buf.pkt - (u64_t)client_sessions[thd].shemem_info[NIC_SHMEM_TX].shm;
+	
+	buf.paddr = data_paddr;
+	buf.pkt_len = pkt_len;
+	tx_pkt_ring_buf_enqueue(g_tx_ring, g_tx_ringbuf, &buf);
+
+	return 0;
+}
+
+static void
+ringbuf_init(struct client_session *session)
+{
+	vaddr_t buf_addr = NULL;
+
+	buf_addr = malloc(RX_PKT_RING_SZ);
+	assert(buf_addr);
+
+	ck_ring_init(buf_addr, RX_PKT_RBUF_SZ);
+
+	session->ring    = buf_addr;
+	session->ringbuf = buf_addr + sizeof(struct ck_ring);
+}
+
+void
+nic_shmem_init(cbuf_t rx_shm_id, cbuf_t tx_shm_id)
+{
+	netshmem_map_shmem(rx_shm_id, tx_shm_id);
+}
+
+int
+nic_bind_port(u32_t ip_addr, u16_t port)
+{
+	unsigned long npages;
+	void         *mem;
+	shm_bm_t shm;
+	cbuf_t shmid;
+	cos_paddr_t paddr = 0;
+	thdid_t thd;
+
+	thd = cos_thdid();
+	assert(thd < NIC_MAX_SESSION);
+
+	client_sessions[thd].ip_addr = ip_addr;
+	client_sessions[thd].port    = port;
+	client_sessions[thd].thd     = thd;
+
+	shm = netshmem_get_rx_shm();
+	shmid = netshmem_get_rx_shm_id();
+	paddr = cos_map_virt_to_phys((cos_vaddr_t)shm);
+	assert(paddr);
+
+	client_sessions[thd].shemem_info[NIC_SHMEM_RX].shmid = shmid;
+	client_sessions[thd].shemem_info[NIC_SHMEM_RX].shm   = shm;
+	client_sessions[thd].shemem_info[NIC_SHMEM_RX].paddr = paddr;
+
+	shm = netshmem_get_tx_shm();
+	shmid = netshmem_get_tx_shm_id();
+	paddr = cos_map_virt_to_phys((cos_vaddr_t)shm);
+	assert(paddr);
+
+	client_sessions[thd].shemem_info[NIC_SHMEM_TX].shmid = shmid;
+	client_sessions[thd].shemem_info[NIC_SHMEM_TX].shm   = shm;
+	client_sessions[thd].shemem_info[NIC_SHMEM_TX].paddr = paddr;
+	printc("dpdk init shmem done\n");
+
+	ringbuf_init(&client_sessions[thd]);
+	return 0;
+}

--- a/src/components/implementation/nicmgr/dpdk/interface_impl.h
+++ b/src/components/implementation/nicmgr/dpdk/interface_impl.h
@@ -1,0 +1,62 @@
+#ifndef INTERFACE_IMPL_H
+#define INTERFACE_IMPL_H
+
+#include <cos_types.h>
+#include <cos_component.h>
+#include <shm_bm.h>
+#include <ck_ring.h>
+
+#define NIC_MAX_SESSION 256
+#define NIC_MAX_SHEMEM_REGION 3
+
+#define NIC_SHMEM_RX 0
+#define NIC_SHMEM_TX 1
+
+struct shemem_info {
+	cbuf_t shmid;
+	shm_bm_t shm;
+
+	paddr_t paddr;
+};
+
+struct pkt_buf {
+	char   *pkt;
+	u64_t   paddr;
+	int     pkt_len;
+};
+
+/* per thread session */
+struct client_session {
+	struct shemem_info shemem_info[NIC_MAX_SHEMEM_REGION];
+
+	thdid_t thd;
+
+	u32_t ip_addr; 
+	u16_t port;
+
+	struct ck_ring *ring;
+	struct pkt_buf *ringbuf;
+};
+
+extern struct ck_ring *g_tx_ring;
+extern struct pkt_buf *g_tx_ringbuf;
+
+extern struct client_session client_sessions[NIC_MAX_SESSION];
+
+#define RX_PKT_RBUF_SZ (64 * sizeof(struct pkt_buf))
+#define RX_PKT_RING_SZ   (sizeof(struct ck_ring) + RX_PKT_RBUF_SZ)
+#define RX_PKT_RING_PAGES (round_up_to_page(RX_PKT_RING_SZ)/PAGE_SIZE)
+
+#define TX_PKT_RBUF_SZ (64 * sizeof(struct pkt_buf))
+#define TX_PKT_RING_SZ   (sizeof(struct ck_ring) + TX_PKT_RBUF_SZ)
+#define TX_PKT_RING_PAGES (round_up_to_page(TX_PKT_RING_SZ)/PAGE_SIZE)
+
+int rx_pkt_ring_buf_enqueue(struct client_session *session, struct pkt_buf *buf);
+int rx_pkt_ring_buf_dequeue(struct client_session *session, struct pkt_buf *buf);
+int rx_pkt_ring_buf_empty(struct client_session *session);
+
+int tx_pkt_ring_buf_enqueue(struct ck_ring *tx_ring, struct pkt_buf *tx_ringbuf, struct pkt_buf *buf);
+int tx_pkt_ring_buf_dequeue(struct ck_ring *tx_ring, struct pkt_buf *tx_ringbuf, struct pkt_buf *buf);
+int tx_pkt_ring_buf_empty(struct ck_ring *tx_ring);
+
+#endif /* INTERFACE_IMPL_H */

--- a/src/components/implementation/simple_tcp_server/Makefile
+++ b/src/components/implementation/simple_tcp_server/Makefile
@@ -3,16 +3,16 @@
 #
 # The set of interfaces that this component exports for use by other
 # components. This is a list of the interface names.
-INTERFACE_EXPORTS = nic 
+INTERFACE_EXPORTS = 
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
-INTERFACE_DEPENDENCIES = netshmem
+INTERFACE_DEPENDENCIES = 
 # The library dependencies this component is reliant on for
 # compilation/linking (this is a list of directory names in lib/)
-LIBRARY_DEPENDENCIES = component dpdk shm_bm ck
+LIBRARY_DEPENDENCIES = component 
 # Note: Both the interface and library dependencies should be
 # *minimal*. That is to say that removing a dependency should cause
 # the build to fail. The build system does not validate this
 # minimality; that's on you!
 
-include Makefile.subsubdir
+include Makefile.subdir

--- a/src/components/implementation/simple_tcp_server/simple_tcp_server/Makefile
+++ b/src/components/implementation/simple_tcp_server/simple_tcp_server/Makefile
@@ -3,13 +3,13 @@
 #
 # The set of interfaces that this component exports for use by other
 # components. This is a list of the interface names.
-INTERFACE_EXPORTS = nic 
+INTERFACE_EXPORTS =
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
-INTERFACE_DEPENDENCIES = netshmem
+INTERFACE_DEPENDENCIES = memmgr contigmem netshmem netmgr
 # The library dependencies this component is reliant on for
 # compilation/linking (this is a list of directory names in lib/)
-LIBRARY_DEPENDENCIES = component dpdk shm_bm ck
+LIBRARY_DEPENDENCIES = component shm_bm 
 # Note: Both the interface and library dependencies should be
 # *minimal*. That is to say that removing a dependency should cause
 # the build to fail. The build system does not validate this

--- a/src/components/implementation/simple_tcp_server/simple_tcp_server/simple_tcp_echo_server.c
+++ b/src/components/implementation/simple_tcp_server/simple_tcp_server/simple_tcp_echo_server.c
@@ -1,0 +1,68 @@
+
+#include <cos_types.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <netmgr.h>
+#include <netshmem.h>
+
+cbuf_t rx_shm_id;
+cbuf_t tx_shm_id;
+
+size_t rx_shmsz;
+size_t tx_shmsz;
+
+shm_bm_t rx_shm;
+shm_bm_t tx_shm;
+
+void
+cos_init(void)
+{
+	shm_bm_objid_t objid;
+	struct netshmem_pkt_buf *obj;
+	netshmem_init();
+
+	netmgr_shmem_init(netshmem_get_rx_shm_id(), netshmem_get_tx_shm_id());
+
+	printc("app init shm done\n");
+}
+
+int
+main(void)
+{
+	int ret		= 0;
+	u32_t ip	= inet_addr("10.10.1.2");
+	u16_t port	= 80;
+	struct conn_addr client_addr;
+	shm_bm_objid_t           objid;
+	struct netshmem_pkt_buf *rx_obj;
+	struct netshmem_pkt_buf *tx_obj;
+	char *data;
+
+	ret = netmgr_tcp_bind(ip, port);
+	assert(ret == NETMGR_OK);
+
+	ret = netmgr_tcp_listen(16);
+	assert(ret == NETMGR_OK);
+
+	printc("App begin to accept connection\n");
+	ret = netmgr_tcp_accept(&client_addr);
+	assert(ret == NETMGR_OK);
+
+	while (1)
+	{
+		/* code */
+		objid = netmgr_tcp_shmem_read();
+		rx_obj = shm_bm_take_rx_pkt_buf(netshmem_get_rx_shm(), objid);
+		
+		data = rx_obj->data + rx_obj->payload_offset;
+
+		tx_obj = shm_bm_alloc_tx_pkt_buf(netshmem_get_tx_shm(), &objid);
+		memcpy(tx_obj->data + NETSHMEM_HEADROOM, data, rx_obj->payload_sz);
+		tx_obj->payload_offset = NETSHMEM_HEADROOM;
+		tx_obj->payload_sz = rx_obj->payload_sz;
+
+		netmgr_tcp_shmem_write(objid);
+	}
+	
+
+}

--- a/src/components/implementation/tests/bench_dpdk/doc.md
+++ b/src/components/implementation/tests/bench_dpdk/doc.md
@@ -10,6 +10,7 @@ sudo apt install -y python3-scapy netsniff-ng
 ```shell
 sudo ip tuntap add dev tap0 mode tap
 sudo ip link set tap0 up
+sudo ip addr add 10.10.1.1/24 dev tap0
 ```
 This will create a `tap` device called `tap0` within your system. You can use `ip a` to check it. After test, you can use this command to delete the `tap0` device:
 ```shell

--- a/src/components/implementation/tests/bench_dpdk/ping-pong.py
+++ b/src/components/implementation/tests/bench_dpdk/ping-pong.py
@@ -11,7 +11,8 @@ def show_packet(packet):
 	os.kill(os.getpid(), signal.SIGTERM)
 
 def send_pkt():
-	sent_pkt = Ether(dst='66:66:66:66:66:66')/IP(src='10.10.1.1', dst='10.10.1.2')/ICMP()
+	sent_pkt = Ether(dst='66:66:66:66:66:66')/IP(src='10.10.1.1', dst='10.10.1.2')/TCP(dport=80, sport=8080)/'aaaaaaaaaaa'
+	hexdump(sent_pkt)
 	sendp(sent_pkt,iface='tap0',filter='inbound and ether dst 66:66:66:66:66:66')
 
 def dump_packet():

--- a/src/components/implementation/tests/bench_dpdk/tcp-test.py
+++ b/src/components/implementation/tests/bench_dpdk/tcp-test.py
@@ -1,0 +1,29 @@
+import socket
+import time
+
+host='10.10.1.2'
+port=80
+
+timeout_seconds=10
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(timeout_seconds)
+result = sock.connect((host,int(port)))
+sock.send('hello composite dpdk lwip and tcp server from client\n'.encode())
+
+# if result == 0:
+#     print("Host: {}, Port: {} - True".format(host, port))
+# else:
+#     print("Host: {}, Port: {} - False".format(host, port))
+time.sleep(5)
+
+data = sock.recv(1000)
+print(data.decode())
+
+
+sock.send('second hello from client\n'.encode())
+
+data = sock.recv(1000)
+print(data.decode())
+
+sock.close()

--- a/src/components/interface/contigmem/Makefile
+++ b/src/components/interface/contigmem/Makefile
@@ -1,0 +1,30 @@
+# Required variables used to drive the compilation process. It is OK
+# for many of these to be empty.
+#
+# The library names associated with .a files output that are linked
+# (via, for example, -lmemmgr) into dependents. This list should be
+# "memmgr" for output files such as libmemmgr.a.
+LIBRARY_OUTPUT = 
+# The .o files that are mandatorily linked into dependents. This is
+# rarely used, and only when normal .a linking rules will avoid
+# linking some necessary objects. This list is of names (for example,
+# memmgr) which will generate memmgr.lib.o. Do NOT include the list of .o
+# files here. Please note that using this list is *very rare* and
+# should only be used when the .a support above is not appropriate.
+OBJECT_OUTPUT =
+# The path within this directory that holds the .h files for
+# dependents to compile with (./ by default). Will be fed into the -I
+# compiler arguments. It is unlikely you want to change this.
+INCLUDE_PATHS = .
+# The interfaces this component is dependent on for compilation (this
+# is a list of directory names in interface/)
+INTERFACE_DEPENDENCIES =
+# The library dependencies this component is reliant on for
+# compilation/linking (this is a list of directory names in lib/)
+LIBRARY_DEPENDENCIES = stubs component
+# Note: Both the interface and library dependencies should be
+# *minimal*. That is to say that removing a dependency should cause
+# the build to fail. The build system does not validate this
+# minimality; that's on you!
+
+include ../Makefile.subdir

--- a/src/components/interface/contigmem/contigmem.h
+++ b/src/components/interface/contigmem/contigmem.h
@@ -1,0 +1,17 @@
+/*
+ * Redistribution of this file is permitted under the BSD two clause license.
+ *
+ * Copyright 2018, The George Washington University
+ * Author: Phani Gadepalli, phanikishoreg@gwu.edu
+ */
+
+#ifndef CONTIGMEM_H
+#define CONTIGMEM_H
+
+#include <cos_types.h>
+#include <cos_component.h>
+#include <cos_stubs.h>
+
+vaddr_t contigmem_alloc(unsigned long npages);
+cbuf_t contigmem_shared_alloc_aligned(unsigned long npages, unsigned long align, vaddr_t *pgaddr);
+#endif /* MEMMGR_H */

--- a/src/components/interface/contigmem/stubs/Makefile
+++ b/src/components/interface/contigmem/stubs/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.subsubdir

--- a/src/components/interface/contigmem/stubs/c_stub.c
+++ b/src/components/interface/contigmem/stubs/c_stub.c
@@ -1,0 +1,16 @@
+#include <cos_component.h>
+#include <cos_stubs.h>
+#include <contigmem.h>
+
+
+COS_CLIENT_STUB(cbuf_t, contigmem_shared_alloc_aligned, unsigned long num_pages, unsigned long align, vaddr_t *pgaddr)
+{
+	COS_CLIENT_INVCAP;
+	word_t unused, addrret;
+	cbuf_t ret;
+
+	ret = cos_sinv_2rets(uc->cap_no, num_pages, align, 0, 0, &addrret, &unused);
+	*pgaddr = addrret;
+
+	return ret;
+}

--- a/src/components/interface/contigmem/stubs/s_stub.c
+++ b/src/components/interface/contigmem/stubs/s_stub.c
@@ -1,0 +1,7 @@
+#include <cos_stubs.h>
+#include <contigmem.h>
+
+COS_SERVER_3RET_STUB(cbuf_t, contigmem_shared_alloc_aligned)
+{
+	return contigmem_shared_alloc_aligned(p0, p1, r1);
+}

--- a/src/components/interface/contigmem/stubs/stubs.S
+++ b/src/components/interface/contigmem/stubs/stubs.S
@@ -1,0 +1,4 @@
+#include <cos_asm_stubs.h>
+
+cos_asm_stub(contigmem_alloc)
+cos_asm_stub_indirect(contigmem_shared_alloc_aligned)

--- a/src/components/interface/netmgr/Makefile
+++ b/src/components/interface/netmgr/Makefile
@@ -1,0 +1,30 @@
+# Required variables used to drive the compilation process. It is OK
+# for many of these to be empty.
+#
+# The library names associated with .a files output that are linked
+# (via, for example, -lmemmgr) into dependents. This list should be
+# "memmgr" for output files such as libmemmgr.a.
+LIBRARY_OUTPUT = 
+# The .o files that are mandatorily linked into dependents. This is
+# rarely used, and only when normal .a linking rules will avoid
+# linking some necessary objects. This list is of names (for example,
+# memmgr) which will generate memmgr.lib.o. Do NOT include the list of .o
+# files here. Please note that using this list is *very rare* and
+# should only be used when the .a support above is not appropriate.
+OBJECT_OUTPUT = 
+# The path within this directory that holds the .h files for
+# dependents to compile with (./ by default). Will be fed into the -I
+# compiler arguments. It is unlikely you want to change this.
+INCLUDE_PATHS = .
+# The interfaces this component is dependent on for compilation (this
+# is a list of directory names in interface/)
+INTERFACE_DEPENDENCIES =
+# The library dependencies this component is reliant on for
+# compilation/linking (this is a list of directory names in lib/)
+LIBRARY_DEPENDENCIES = stubs component
+# Note: Both the interface and library dependencies should be
+# *minimal*. That is to say that removing a dependency should cause
+# the build to fail. The build system does not validate this
+# minimality; that's on you!
+
+include ../Makefile.subdir

--- a/src/components/interface/netmgr/netmgr.h
+++ b/src/components/interface/netmgr/netmgr.h
@@ -1,0 +1,37 @@
+#ifndef NETMGR_H
+#define NETMGR_H
+
+#include <cos_types.h>
+#include <cos_component.h>
+#include <cos_stubs.h>
+#include <shm_bm.h>
+
+#define NETMGR_OK (0)
+
+struct conn_addr {
+	u32_t ip;
+	u16_t port;
+};
+
+void netmgr_shmem_init(cbuf_t rx_shm_id, cbuf_t tx_shm_id);
+
+int netmgr_tcp_bind(u32_t ip_addr, u16_t port);
+
+int netmgr_tcp_listen(u8_t backlog);
+int netmgr_tcp_accept(struct conn_addr *client_addr);
+
+// int net_tcp_read(void* buf, size_t sz);
+// int net_tcp_write(void* buf, size_t sz);
+
+shm_bm_objid_t netmgr_tcp_shmem_read();
+int netmgr_tcp_shmem_write(shm_bm_objid_t objid);
+
+// int net_udp_bind_port(u32_t ip_addr, u16_t port);
+
+// int net_udp_read(void* buf, size_t sz);
+// int net_udp_write(void* buf, size_t sz);
+
+// int net_udp_read_with_shmem();
+// int net_udp_write_with_shmem();
+
+#endif /* NETMGR_H */

--- a/src/components/interface/netmgr/stubs/Makefile
+++ b/src/components/interface/netmgr/stubs/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.subsubdir

--- a/src/components/interface/netmgr/stubs/stubs.S
+++ b/src/components/interface/netmgr/stubs/stubs.S
@@ -1,0 +1,8 @@
+#include <cos_asm_stubs.h>
+
+cos_asm_stub(netmgr_tcp_bind)
+cos_asm_stub(netmgr_shmem_init)
+cos_asm_stub(netmgr_tcp_listen)
+cos_asm_stub(netmgr_tcp_accept)
+cos_asm_stub(netmgr_tcp_shmem_read)
+cos_asm_stub(netmgr_tcp_shmem_write)

--- a/src/components/interface/netshmem/Makefile
+++ b/src/components/interface/netshmem/Makefile
@@ -1,0 +1,30 @@
+# Required variables used to drive the compilation process. It is OK
+# for many of these to be empty.
+#
+# The library names associated with .a files output that are linked
+# (via, for example, -lpongshmem) into dependents. This list should be
+# "pongshmem" for output files such as libpongshmem.a.
+LIBRARY_OUTPUT = netshmem
+# The .o files that are mandatorily linked into dependents. This is
+# rarely used, and only when normal .a linking rules will avoid
+# linking some necessary objects. This list is of names (for example,
+# pongshmem) which will generate pongshmem.lib.o. Do NOT include the list of .o
+# files here. Please note that using this list is *very rare* and
+# should only be used when the .a support above is not appropriate.
+OBJECT_OUTPUT =
+# The path within this directory that holds the .h files for
+# dependents to compile with (./ by default). Will be fed into the -I
+# compiler arguments. It is unlikely you want to change this.
+INCLUDE_PATHS = .
+# The interfaces this component is dependent on for compilation (this
+# is a list of directory names in interface/)
+INTERFACE_DEPENDENCIES =
+# The library dependencies this component is reliant on for
+# compilation/linking (this is a list of directory names in lib/)
+LIBRARY_DEPENDENCIES = stubs shm_bm
+# Note: Both the interface and library dependencies should be
+# *minimal*. That is to say that removing a dependency should cause
+# the build to fail. The build system does not validate this
+# minimality; that's on you!
+
+include Makefile.subdir

--- a/src/components/interface/netshmem/lib.c
+++ b/src/components/interface/netshmem/lib.c
@@ -1,0 +1,75 @@
+#include "netshmem.h"
+
+struct netshmem netshmems[NETSHMEM_REGION_SZ];
+
+void
+netshmem_init(void)
+{
+	shm_bm_objid_t objid;
+	struct netshmem_pkt_buf *obj;
+	void  *mem;
+
+	/* init rx shmem */
+	netshmems[NETSHMEM_RX].shmsz	= round_up_to_page(shm_bm_size_rx_pkt_buf());
+	netshmems[NETSHMEM_RX].shm_id	= contigmem_shared_alloc_aligned(netshmems[NETSHMEM_RX].shmsz/PAGE_SIZE, SHM_BM_ALIGN, (vaddr_t *)&mem);
+	netshmems[NETSHMEM_RX].shm	= shm_bm_create_rx_pkt_buf(mem, netshmems[NETSHMEM_RX].shmsz);
+
+	shm_bm_init_rx_pkt_buf(netshmems[NETSHMEM_RX].shm);
+
+	/* init tx shmem */
+	netshmems[NETSHMEM_TX].shmsz	= round_up_to_page(shm_bm_size_tx_pkt_buf());
+	netshmems[NETSHMEM_TX].shm_id	= contigmem_shared_alloc_aligned(netshmems[NETSHMEM_TX].shmsz/PAGE_SIZE, SHM_BM_ALIGN, (vaddr_t *)&mem);
+	netshmems[NETSHMEM_TX].shm	= shm_bm_create_rx_pkt_buf(mem, netshmems[NETSHMEM_TX].shmsz);
+
+	shm_bm_init_tx_pkt_buf(netshmems[NETSHMEM_TX].shm);
+}
+
+cbuf_t
+netshmem_get_rx_shm_id(void)
+{
+	return netshmems[NETSHMEM_RX].shm_id;
+}
+
+cbuf_t
+netshmem_get_tx_shm_id(void)
+{
+	return netshmems[NETSHMEM_TX].shm_id;
+}
+
+shm_bm_t
+netshmem_get_rx_shm(void)
+{
+	return netshmems[NETSHMEM_RX].shm;
+}
+
+shm_bm_t
+netshmem_get_tx_shm(void)
+{
+	return netshmems[NETSHMEM_TX].shm;
+}
+
+void
+netshmem_map_shmem(cbuf_t rx_shm_id, cbuf_t tx_shm_id)
+{
+	unsigned long npages;
+	void         *mem;
+	shm_bm_t shm;
+
+	npages	= memmgr_shared_page_map_aligned(rx_shm_id, SHM_BM_ALIGN, (vaddr_t *)&mem);
+	// printc("npages:%u\n",npages);
+	shm	= shm_bm_create_rx_pkt_buf(mem, npages * PAGE_SIZE);
+	assert(shm);
+
+	netshmems[NETSHMEM_RX].shm = shm;
+	netshmems[NETSHMEM_RX].shm_id = rx_shm_id;
+	netshmems[NETSHMEM_RX].shmsz = npages * PAGE_SIZE;
+
+	npages	= memmgr_shared_page_map_aligned(tx_shm_id, SHM_BM_ALIGN, (vaddr_t *)&mem);
+	shm	= shm_bm_create_tx_pkt_buf(mem, npages * PAGE_SIZE);
+
+	assert(shm);
+
+	netshmems[NETSHMEM_TX].shm = shm;
+	netshmems[NETSHMEM_TX].shm_id = tx_shm_id;
+	netshmems[NETSHMEM_TX].shmsz = npages * PAGE_SIZE;
+}

--- a/src/components/interface/netshmem/netshmem.h
+++ b/src/components/interface/netshmem/netshmem.h
@@ -1,0 +1,47 @@
+#ifndef NETSHMEM_H
+#define NETSHMEM_H
+
+#include <cos_component.h>
+#include <shm_bm.h>
+
+#define PKT_BUF_NUM 4096
+#define PKT_BUF_SIZE 2000
+#define PKT_BUF_HEAD_ROOM 500
+
+struct netshmem {
+	size_t shmsz;
+	shm_bm_t shm;
+	cbuf_t shm_id;
+};
+
+#define NETSHMEM_RX 0
+#define NETSHMEM_TX 1
+#define NETSHMEM_REGION_SZ 2
+
+/*
+ * This is the offset size of netshmem_pkt_buf.data for application to write data.
+ * HEADROOM is used for lwip to set ether & ip & tcp/udp headers
+ */
+
+#define NETSHMEM_HEADROOM 128
+
+struct netshmem_pkt_buf {
+	char data[PKT_BUF_SIZE];
+	u32_t payload_offset; /* offset of payload data within data member */
+	int payload_sz;
+	shm_bm_objid_t objid; /* self reference */
+};
+
+SHM_BM_INTERFACE_CREATE(rx_pkt_buf, sizeof (struct netshmem_pkt_buf), PKT_BUF_NUM);
+SHM_BM_INTERFACE_CREATE(tx_pkt_buf, sizeof (struct netshmem_pkt_buf), PKT_BUF_NUM);
+
+void netshmem_init(void);
+cbuf_t netshmem_get_rx_shm_id(void);
+cbuf_t netshmem_get_tx_shm_id(void);
+
+shm_bm_t netshmem_get_rx_shm(void);
+shm_bm_t netshmem_get_tx_shm(void);
+
+void netshmem_map_shmem(cbuf_t rx_shm_id, cbuf_t tx_shm_id);
+
+#endif

--- a/src/components/interface/netshmem/stubs/Makefile
+++ b/src/components/interface/netshmem/stubs/Makefile
@@ -1,0 +1,1 @@
+include Makefile.subsubdir

--- a/src/components/interface/netshmem/stubs/stubs.S
+++ b/src/components/interface/netshmem/stubs/stubs.S
@@ -1,0 +1,2 @@
+#include <cos_asm_stubs.h>
+

--- a/src/components/interface/nic/nic.h
+++ b/src/components/interface/nic/nic.h
@@ -4,8 +4,17 @@
 #include <cos_types.h>
 #include <cos_component.h>
 #include <cos_stubs.h>
+#include <shm_bm.h>
 
-int nic_send_packet(char* pkt, size_t pkt_size);
-int nic_bind_port(u32_t ip_addr, u16_t port, void* share_mem, size_t share_mem_sz);
+void nic_shmem_init(cbuf_t rx_shm_id, cbuf_t tx_shm_id);
 
+int nic_send_packet(shm_bm_objid_t pktid, u16_t pkt_size);
+int nic_bind_port(u32_t ip_addr, u16_t port);
+
+/*
+ * caller will be suspended until there is a packet for this thread,
+ * dpdk will then copy the packet to this shmem region specified by the shmid
+ * and return its shmem objectid.
+ */
+shm_bm_objid_t nic_get_a_packet();
 #endif /* NIC_H */

--- a/src/components/interface/nic/stubs/stubs.S
+++ b/src/components/interface/nic/stubs/stubs.S
@@ -2,3 +2,5 @@
 
 cos_asm_stub(nic_send_packet)
 cos_asm_stub(nic_bind_port)
+cos_asm_stub(nic_get_a_packet)
+cos_asm_stub(nic_shmem_init)

--- a/src/components/lib/dpdk/Makefile
+++ b/src/components/lib/dpdk/Makefile
@@ -43,7 +43,7 @@ DISABLED_DRIVERS=-Ddisable_drivers=common/mvep,common/mlx5,af_xdp,net/ipn3ke,net
 	raw/dpaa2_cmdif,raw/dpaa2_qdma,raw/ioat,raw/ntb,raw/octeontx2_dma,raw/octeontx2_ep,raw/skeleton,common/cpt,common/dpaax,$\
 	common/iavf,common/octeontx,common/octeontx2,common/cnxk,common/qat,common/sfc_efx,bus/auxiliary,bus/dpaa,bus/fslmc,$\
 	bus/ifpga,net/af_packet,net/ark,net/atlantic,net/avp,net/axgbe,net/bnx2x,net/bnxt,net/bond,net/cxgbe,net/ena,net/enic,$\
-	net/failsafe,net/fm10k,net/hinic,net/hns3,net/i40e,net/igc,net/ionic,net/ixgbe,net/kni,net/liquidio,net/memif,net/nfp,$\
+	net/failsafe,net/fm10k,net/hinic,net/hns3,net/igc,net/ionic,net/ixgbe,net/kni,net/liquidio,net/memif,net/nfp,$\
 	net/ngbe,net/null,net/pcap,net/qede,net/softnic,net/thunderx,net/txgbe,net/vdev_netvsc,baseband/la12xx,dma/idxd,dma/ioat,$\
 	dma/skeleton,net/octeontx_ep,
 

--- a/src/components/lib/dpdk/adapter/cos_dpdk_adapter.c
+++ b/src/components/lib/dpdk/adapter/cos_dpdk_adapter.c
@@ -191,4 +191,5 @@ cos_get_tsc_freq(void)
 }
 
 COS_DPDK_DECLARE_NIC_MODULE(net_e1000_em);
+COS_DPDK_DECLARE_NIC_MODULE(net_i40e);
 COS_DPDK_DECLARE_NIC_MODULE(mempool_ring);

--- a/src/components/lib/dpdk/cos_dpdk.c
+++ b/src/components/lib/dpdk/cos_dpdk.c
@@ -432,8 +432,10 @@ cos_dev_port_tx_burst(cos_portid_t port_id, uint16_t queue_id,
  * cos_parse_pkts: return data pointer of this packet
  */
 char*
-cos_get_packet(char* mbuf)
+cos_get_packet(char* mbuf, int *len)
 {
+
+	*len = ((struct rte_mbuf*)mbuf)->pkt_len;
 	return (char *)rte_pktmbuf_mtod((struct rte_mbuf*)mbuf, struct rte_ether_hdr *);
 }
 
@@ -520,10 +522,40 @@ uint16_t cos_send_a_packet(char * pkt, uint32_t pkt_size, char* mp)
 	mbuf->data_len = pkt_size + sizeof(struct rte_ether_hdr);
 	mbuf->pkt_len = pkt_size + sizeof(struct rte_ether_hdr);
 
-	return cos_dev_port_tx_burst(0, 0, (char**)&mbuf, 1);
+	return cos_dev_port_tx_burst(0, 0, (char **)&mbuf, 1);
 }
 
 char*
 cos_allocate_mbuf(char* mp) {
-	return (char*)rte_pktmbuf_alloc((struct rte_mempool *)mp);
+	return (char *)rte_pktmbuf_alloc((struct rte_mempool *)mp);
+}
+
+int
+cos_attach_external_mbuf(char *mbuf, void *buf_vaddr, uint16_t buf_len,
+			void (*ext_buf_free_cb)(void *addr, void *opaque),
+			uint64_t buf_paddr)
+{
+	struct rte_mbuf_ext_shared_info *ret_shinfo = NULL;
+	rte_iova_t buf_iova =buf_paddr ;
+	bool freed = false;
+
+	uint16_t ext_buf_len = buf_len + sizeof(struct rte_mbuf_ext_shared_info);
+
+	struct rte_mbuf *_mbuf = (struct rte_mbuf *)mbuf;
+
+	ret_shinfo = rte_pktmbuf_ext_shinfo_init_helper(buf_vaddr, &ext_buf_len, ext_buf_free_cb, &freed);
+	rte_pktmbuf_attach_extbuf(_mbuf, buf_vaddr, buf_iova, ext_buf_len, ret_shinfo);
+	assert(_mbuf->ol_flags == RTE_MBUF_F_EXTERNAL);
+
+	return 0;
+}
+
+int
+cos_send_external_packet(char*mbuf, uint16_t pkt_len)
+{
+	struct rte_mbuf *_mbuf = (struct rte_mbuf *)mbuf;
+	_mbuf->data_len = pkt_len;
+	_mbuf->pkt_len = pkt_len;
+
+	return cos_dev_port_tx_burst(0, 0, &mbuf, 1);
 }

--- a/src/components/lib/dpdk/cos_dpdk.h
+++ b/src/components/lib/dpdk/cos_dpdk.h
@@ -72,8 +72,14 @@ uint16_t cos_dev_port_tx_burst(cos_portid_t port_id, uint16_t queue_id,
 
 void cos_get_port_stats(cos_portid_t port_id);
 
-char* cos_get_packet(char* mbuf);
+char* cos_get_packet(char* mbuf, int *len);
 uint16_t cos_send_a_packet(char * pkt, uint32_t pkt_size, char* mp);
 char* cos_allocate_mbuf(char* mp);
+
+int cos_attach_external_mbuf(char *mbuf, void *buf_vaddr, uint16_t buf_len,
+			void (*ext_buf_free_cb)(void *addr, void *opaque),
+			uint64_t buf_paddr);
+
+int cos_send_external_packet(char*mbuf, u16_t pkt_len);
 
 #endif /* COS_DPDK_H */

--- a/src/components/lib/lwip/Makefile
+++ b/src/components/lib/lwip/Makefile
@@ -7,7 +7,7 @@ LIBRARY_OUTPUT = lwip
 
 OBJECT_OUTPUT =
 
-INCLUDE_PATHS = . cos_adapter lwip/src/include
+INCLUDE_PATHS = cos_adapter lwip/src/include
 
 INTERFACE_DEPENDENCIES =
 
@@ -34,7 +34,7 @@ LWIP_CORE_FILES=$(LWIP_DIR)/core/mem.c $(LWIP_DIR)/core/memp.c $(LWIP_DIR)/core/
 	$(LWIP_DIR)/api/err.c
 
 LWIP_CORE_IPV4_FILES=$(LWIP_DIR)/core/ipv4/icmp.c $(LWIP_DIR)/core/ipv4/ip4.c \
-	$(LWIP_DIR)/core/ipv4/ip4_addr.c $(LWIP_DIR)/core/ipv4/ip4_frag.c
+	$(LWIP_DIR)/core/ipv4/ip4_addr.c $(LWIP_DIR)/core/ipv4/ip4_frag.c $(LWIP_DIR)/core/ipv4/etharp.c $(LWIP_DIR)/netif/ethernet.c
 COS_LWIP_ADAPTER_FILES=$(LWIP_ADAPTER_DIR)/sys_arch.c
 
 LWIP_FILES=$(LWIP_CORE_FILES) $(LWIP_CORE_IPV4_FILES) $(COS_LWIP_ADAPTER_FILES)

--- a/src/components/lib/lwip/cos_adapter/lwipopts.h
+++ b/src/components/lib/lwip/cos_adapter/lwipopts.h
@@ -1,20 +1,25 @@
 #ifndef LWIPOPTS_H
 #define LWIPOPTS_H
 
-#define MEM_LIBC_MALLOC 1
+#define MEM_LIBC_MALLOC 0
 #define MEM_USE_POOLS 0
 
 #define NO_SYS 1
-#define MEM_ALIGNMENT 4
-#define MEM_SIZE 0 //64000
-/* #define MEMP_OVERFLOW_CHECK 1 */
-/* #define MEMP_SANITY_CHECK 1 */
-/* #define MEMP_NUM_PBUF (4096*4) */
+#define MEM_ALIGNMENT 8
+#define MEM_SIZE  (12 * 1024)//64000
+// #define MEMP_OVERFLOW_CHECK 1
+// #define MEMP_SANITY_CHECK 1
+#define MEMP_NUM_PBUF (4096*4)
+
+#define LWIP_ETHERNET 1
+#define LWIP_ARP 1
+#define ETHARP_SUPPORT_STATIC_ENTRIES 1
+#define LWIP_IPV4 1
+
 #define MEMP_NUM_UDP_PCB 512
 
 #define MEMP_NUM_TCP_PCB 512 	/* need a fair amount of these due to timed wait on close  */
 #define MEMP_NUM_TCP_PCB_LISTEN 128
-#define LWIP_ARP 0
 #define IP_REASSEMBLY 0
 #define IP_FRAG 0
 
@@ -56,7 +61,7 @@
 #define LWIP_NETCONN 0
 #define LWIP_ICMP   1
 
-#define LWIP_DEBUG  1
+#define LWIP_DEBUG  0
 
 
  #define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_ALL
@@ -65,40 +70,41 @@
 //#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_SEVERE
 
 //#define LWIP_DBG_TYPES_ON               LWIP_DBG_ON
-#define LWIP_DBG_TYPES_ON               (LWIP_DBG_ON|LWIP_DBG_TRACE|LWIP_DBG_STATE|LWIP_DBG_FRESH)
+// #define LWIP_DBG_TYPES_ON               (LWIP_DBG_ON|LWIP_DBG_TRACE|LWIP_DBG_STATE|LWIP_DBG_FRESH)
 
-#define ETHARP_DEBUG                    LWIP_DBG_ON
-#define NETIF_DEBUG                     LWIP_DBG_ON
-#define PBUF_DEBUG                      LWIP_DBG_ON
-#define API_LIB_DEBUG                   LWIP_DBG_ON
-#define API_MSG_DEBUG                   LWIP_DBG_ON
-#define SOCKETS_DEBUG                   LWIP_DBG_ON
-#define ICMP_DEBUG                      LWIP_DBG_ON
-#define IGMP_DEBUG                      LWIP_DBG_ON
-#define INET_DEBUG                      LWIP_DBG_ON
-#define IP_DEBUG                        LWIP_DBG_ON
-#define IP_REASS_DEBUG                  LWIP_DBG_ON
-#define RAW_DEBUG                       LWIP_DBG_ON
-#define MEM_DEBUG                       LWIP_DBG_ON
-#define MEMP_DEBUG                      LWIP_DBG_ON
-#define SYS_DEBUG                       LWIP_DBG_ON
-#define TCP_DEBUG                       LWIP_DBG_ON
-#define TCP_INPUT_DEBUG                 LWIP_DBG_ON
-#define TCP_FR_DEBUG                    LWIP_DBG_ON
-#define TCP_RTO_DEBUG                   LWIP_DBG_ON
-#define TCP_CWND_DEBUG                  LWIP_DBG_ON
-#define TCP_WND_DEBUG                   LWIP_DBG_ON
-#define TCP_OUTPUT_DEBUG                LWIP_DBG_ON
-#define TCP_RST_DEBUG                   LWIP_DBG_ON
-#define TCP_QLEN_DEBUG                  LWIP_DBG_ON
-#define UDP_DEBUG                       LWIP_DBG_ON
-#define TCPIP_DEBUG                     LWIP_DBG_ON
-#define PPP_DEBUG                       LWIP_DBG_ON
-#define SLIP_DEBUG                      LWIP_DBG_ON
-#define DHCP_DEBUG                      LWIP_DBG_ON
-#define AUTOIP_DEBUG                    LWIP_DBG_ON
-#define SNMP_MSG_DEBUG                  LWIP_DBG_ON
-#define SNMP_MIB_DEBUG                  LWIP_DBG_ON
-#define DNS_DEBUG                       LWIP_DBG_ON 
+// #define ETHARP_DEBUG                    LWIP_DBG_ON
+// #define NETIF_DEBUG                     LWIP_DBG_ON
+// #define PBUF_DEBUG                      LWIP_DBG_ON
+// #define API_LIB_DEBUG                   LWIP_DBG_ON
+// #define API_MSG_DEBUG                   LWIP_DBG_ON
+// #define SOCKETS_DEBUG                   LWIP_DBG_ON
+// #define ICMP_DEBUG                      LWIP_DBG_ON
+// #define IGMP_DEBUG                      LWIP_DBG_ON
+// #define INET_DEBUG                      LWIP_DBG_ON
+// #define IP_DEBUG                        LWIP_DBG_ON
+// #define IP_REASS_DEBUG                  LWIP_DBG_ON
+// #define RAW_DEBUG                       LWIP_DBG_ON
+// #define MEM_DEBUG                       LWIP_DBG_ON
+// #define MEMP_DEBUG                      LWIP_DBG_ON
+// #define SYS_DEBUG                       LWIP_DBG_ON
+// #define TCP_DEBUG                       LWIP_DBG_ON
+// #define TCP_INPUT_DEBUG                 LWIP_DBG_ON
+// #define TCP_FR_DEBUG                    LWIP_DBG_ON
+// #define TCP_RTO_DEBUG                   LWIP_DBG_ON
+// #define TCP_CWND_DEBUG                  LWIP_DBG_ON
+// #define TCP_WND_DEBUG                   LWIP_DBG_ON
+// #define TCP_OUTPUT_DEBUG                LWIP_DBG_ON
+// #define TCP_RST_DEBUG                   LWIP_DBG_ON
+// #define TCP_QLEN_DEBUG                  LWIP_DBG_ON
+// #define UDP_DEBUG                       LWIP_DBG_ON
+// #define TCPIP_DEBUG                     LWIP_DBG_ON
+// #define PPP_DEBUG                       LWIP_DBG_ON
+// #define SLIP_DEBUG                      LWIP_DBG_ON
+// #define DHCP_DEBUG                      LWIP_DBG_ON
+// #define AUTOIP_DEBUG                    LWIP_DBG_ON
+// #define SNMP_MSG_DEBUG                  LWIP_DBG_ON
+// #define SNMP_MIB_DEBUG                  LWIP_DBG_ON
+// #define DNS_DEBUG                       LWIP_DBG_ON 
+
 
 #endif	/* LWIPOPTS_H */

--- a/src/components/lib/posix_cap/Makefile
+++ b/src/components/lib/posix_cap/Makefile
@@ -18,7 +18,7 @@ OBJECT_OUTPUT = posix_cap
 INCLUDE_PATHS = .
 # The interfaces this component is dependent on for compilation (this
 # is a list of directory names in interface/)
-INTERFACE_DEPENDENCIES = memmgr sched
+INTERFACE_DEPENDENCIES = memmgr sched contigmem
 # The library dependencies this component is reliant on for
 # compilation/linking (this is a list of directory names in lib/)
 LIBRARY_DEPENDENCIES = component kernel posix

--- a/src/components/lib/posix_cap/posix_cap.c
+++ b/src/components/lib/posix_cap/posix_cap.c
@@ -15,6 +15,7 @@
 #include <posix.h>
 #include <ps_list.h>
 #include <memmgr.h>
+#include <contigmem.h>
 
 static struct ps_lock stdout_lock;
 
@@ -96,7 +97,7 @@ cos_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 		return MAP_FAILED;
 	}
 
-	addr = (void *)memmgr_heap_page_allocn((length / PAGE_SIZE));
+	addr = (void *)contigmem_alloc((length / PAGE_SIZE));
 	if (!addr){
 		ret = (void *) -1;
 	} else {

--- a/src/components/lib/posix_legacy/posix_legacy.c
+++ b/src/components/lib/posix_legacy/posix_legacy.c
@@ -291,7 +291,7 @@ cos_clone(int (*func)(void *), void *stack, int flags, void *arg, pid_t *ptid, v
 		return -1;
 	}
 
-	struct sl_thd * thd = sl_thd_alloc((cos_thd_fn_t)func, arg);
+	struct sl_thd * thd = sl_thd_alloc((cos_thd_fn_t)(void *)func, arg);
 	if (tls) {
 		setup_thread_area(thd, tls);
 	}
@@ -489,7 +489,7 @@ syscall_emulation_setup(void)
 	libc_syscall_override((cos_syscall_t)(void*)cos_mprotect, __NR_mprotect);
 
 	libc_syscall_override((cos_syscall_t)(void*)cos_gettid, __NR_gettid);
-	libc_syscall_override((cos_syscall_t)cos_tkill, __NR_tkill);
+	libc_syscall_override((cos_syscall_t)(void*)cos_tkill, __NR_tkill);
 #if defined(__x86__)
 	libc_syscall_override((cos_syscall_t)(void*)cos_mmap, __NR_mmap);
 	libc_syscall_override((cos_syscall_t)(void*)cos_set_thread_area, __NR_set_thread_area);

--- a/src/components/lib/ps/Makefile
+++ b/src/components/lib/ps/Makefile
@@ -71,7 +71,9 @@ clean_lib:
 	make -C ps clean
 
 # need to make sure the ps_plat.h is always available
-clean: config clean_lib
+clean:
+
+distclean: config clean_lib
 
 armv7a_config:
 	$(info Configuring the ps library)
@@ -88,5 +90,4 @@ x86_64_config:
 config: $(PLATFORM)_config
 	make -C ps config
 
-init: clean all
-distclean: clean
+init: distclean all


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Adds a simple tcp server component and test the full path of receiving & transmitting of the system. There are three components that need to be read:

+ The DPDK/NIC component: it uses a single thread to process rx/tx packets, with the help of ck_ring buffer. It has 2 ck_ring buffers, one for receiving packets, and the other for transmitting packets. Notice that it does not have a hash table to redirect connections because currently we only have one single thread tcp server to process requests. Another small idea there is that I want to support the ARP protocol, so that the connection does not need to configure MAC addresses. That's why there is a switch condition within the receiving loop.

+ The LWIP component: it implements a `netmgr` interface, which is similar to linux style socket API. For example, it implements functions like `netmgr_tcp_bind`, `netmgr_tcp_listen` and `netmgr_tcp_accept`. Notice that the `netmgr_tcp_accept` is a blocking API. Current implementation only uses three gloabl variables `return_flag`, `g_pbuf` and `g_objid` to indicate whether the thread should return from `tcp_recv`. The LWIP sending logic `cos_interface_output` is a little opeaque because: 1. It needs to know whether the pbuf comes from a shared memory or not. 2. If it is not a shared memory case, it needs to copy the full packet content to the shared memory for sending. 3. If it is a shared memory case, the pbuf is chained actually 2 pieces. The first piece is the packet header created by the lwip, the second one is the shared memory referenced by a `PBUF_ROM` pbuf. Thus, we need to copy the headers to our shared memory for DPDK to send it out. Normally, the headers consist of a 20-bytes TCP header, 20-bytes IP header and a 14-byte ether header, totally 54 bytes that needs to be copied when sending out shared memory packets.

+ The TCP application component: It uses interfaces provided by the shared memory and `netmgr` to process connections. Each time when it receives a message (a packet/a shared memory), it allocates a sending shared memory block and copy the original receiving data to the sending buffer. And finally send it out.

There is also a simple python based tcp client (`tcp-test.py`) to test the tcp echo server. 

There are still some other infrastructures needed, like the DPDK connection hashing function, a more user-friendly share memory API. Thus,  this PR is only for a code review to see if there are some major problems of the implementation of our network stack facilities. 

Thank you very much for the review.

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer @WenyuanShao @evanstella 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [ ] Comments adhere to the Style Guide (SG)
- [ ] Spacing adhere's to the SG
- [ ] Naming adhere's to the SG
- [ ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [ ] unit_pingpong
- [ ] unit_schedtests
- [ ] ...(add others here)
