### PR TITLE
fix tls update issue

### DIFF
--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -62,11 +62,7 @@ struct thread {
 	struct invstk_entry invstk[THD_INVSTK_MAXSZ];
 
 	thd_state_t    state;
-#if defined(__x86_64__)
-	u64_t          tls;
-#else
-	u32_t          tls;
-#endif
+	word_t          tls;
 	cpuid_t        cpuid;
 	unsigned int   refcnt;
 	tcap_res_t     exec; /* execution time */

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -62,7 +62,11 @@ struct thread {
 	struct invstk_entry invstk[THD_INVSTK_MAXSZ];
 
 	thd_state_t    state;
+#if defined(__x86_64__)
+	u64_t          tls;
+#else
 	u32_t          tls;
+#endif
 	cpuid_t        cpuid;
 	unsigned int   refcnt;
 	tcap_res_t     exec; /* execution time */

--- a/src/platform/i386/chal/call_convention.h
+++ b/src/platform/i386/chal/call_convention.h
@@ -167,10 +167,16 @@ copy_all_regs(struct pt_regs *from, struct pt_regs *to)
 	COPY_REG(di);
 	COPY_REG(bp);
 	COPY_REG(ax);
-	COPY_REG(ds);
-	COPY_REG(es);
-	COPY_REG(fs);
-	COPY_REG(gs);
+/*
+ * These four segment registers don't need to be copied
+ * because user space cannot modified them, and the kernel
+ * also doesn't need to change its value.
+ */
+	// COPY_REG(ds);
+	// COPY_REG(es);
+	// COPY_REG(fs);
+	// COPY_REG(gs);
+
 	COPY_REG(orig_ax);
 	COPY_REG(ip);
 	COPY_REG(cs);

--- a/src/platform/i386/exception.c
+++ b/src/platform/i386/exception.c
@@ -119,17 +119,18 @@ page_fault_handler(struct pt_regs *regs)
 {
 	unsigned long                      fault_addr = 0, errcode = 0, ip = 0;
 	struct cos_cpu_local_info *ci    = cos_cpu_local_info();
-	thdid_t                    thdid = thd_current(ci)->tid;
+	struct thread * curr             = thd_current(ci);
+	thdid_t                    thdid = curr->tid;
 
 	print_pt_regs(regs);
 	fault_addr = chal_cpu_fault_vaddr(regs);
 	errcode    = chal_cpu_fault_errcode(regs);
 	ip        = chal_cpu_fault_ip(regs);
 
-	die("FAULT: Page Fault in thd %d (%s %s %s %s %s) @ 0x%p, ip 0x%p\n", thdid,
+	die("FAULT: Page Fault in thd %d (%s %s %s %s %s) @ 0x%p, ip 0x%p, tls 0x%p\n", thdid,
 	    errcode & PGTBL_PRESENT ? "present" : "not-present",
 	    errcode & PGTBL_WRITABLE ? "write-fault" : "read-fault", errcode & PGTBL_USER ? "user-mode" : "system",
-	    errcode & PGTBL_WT ? "reserved" : "", errcode & PGTBL_NOCACHE ? "instruction-fetch" : "", fault_addr, ip);
+	    errcode & PGTBL_WT ? "reserved" : "", errcode & PGTBL_NOCACHE ? "instruction-fetch" : "", fault_addr, ip, curr->tls);
 
 	return 1;
 }

--- a/src/platform/i386/printk.c
+++ b/src/platform/i386/printk.c
@@ -34,6 +34,7 @@ printk(const char *fmt, ...)
 void
 print_pt_regs(struct pt_regs *regs)
 {
+/* Remember that %ds, %es, %fs, %gs will be ignored when saving them, thus values of them here are possible be random. */
 #if defined(__x86_64__)
 	PRINTK("Register hexdump (0x%p):\n", regs);
 	PRINTK("General->   RAX: 0x%p, RBX: 0x%p, RCX: 0x%p, RDX: 0x%p\n",

--- a/src/platform/x86_64/entry.S
+++ b/src/platform/x86_64/entry.S
@@ -75,8 +75,7 @@ restore_from_thd:
 	movq %rax, %ds
 	popq %rax
 	movq %rax, %es
-	popq %rax
-	movq %rax, %gs
+	addq $0x10, %rsp
 	RESTORE_REGS_GENERAL
 
 	addq $8, %rsp
@@ -86,12 +85,11 @@ restore_from_thd:
 
 #define IRQPROC(fn)  \
 	SAVE_REGS_GENERAL; 	\
-	movq %gs, %rax;		\
-	pushq %rax;			\
+	subq $0x10, %rsp;	\
 	movq %es, %rax;		\
-	pushq %rax;			\
+	pushq %rax;		\
 	movq %ds, %rax;		\
-	pushq %rax;			\
+	pushq %rax;		\
 	movq $(SEL_KDSEG), %rax;\
 	mov %rax, %ds;		\
 	mov %rsp, %rdi; 	\

--- a/src/platform/x86_64/entry.S
+++ b/src/platform/x86_64/entry.S
@@ -69,13 +69,14 @@ sysenter_entry:
 	RET_TO_USER		
 /* we are changing thread contexts, reload all registers */
 
+/* on restoring path, only the %ds will be taken care of. */
 .align 16
 restore_from_thd:
-	popq %rax
-	movq %rax, %ds
-	popq %rax
-	movq %rax, %es
-	addq $0x10, %rsp
+	/* %ds is constant, and %es, %fs, %gs are not used because they cannot be modified by user space and kernel also does not modify them, thus we just add 0x20 to %rsp */
+	addq $0x20, %rsp
+	/* user space will only use one constant %ds selector, thus we don't push/pop it, instead we just set the value in order to save some cycles. */
+	mov $(SEL_UDSEG), %rax
+	mov %rax, %ds
 	RESTORE_REGS_GENERAL
 
 	addq $8, %rsp
@@ -83,13 +84,10 @@ restore_from_thd:
 	sti
 	iretq
 
+/* %ds, %es, %fs, %gs are all ingored when saving. */
 #define IRQPROC(fn)  \
 	SAVE_REGS_GENERAL; 	\
-	subq $0x10, %rsp;	\
-	movq %es, %rax;		\
-	pushq %rax;		\
-	movq %ds, %rax;		\
-	pushq %rax;		\
+	subq $0x20, %rsp;	\
 	movq $(SEL_KDSEG), %rax;\
 	mov %rax, %ds;		\
 	mov %rsp, %rdi; 	\

--- a/src/platform/x86_64/gdt.c
+++ b/src/platform/x86_64/gdt.c
@@ -20,8 +20,6 @@ static void flush_selectors(void);
 void
 chal_tls_update(vaddr_t addr)
 {
-	int cpu_id = get_cpuid();
-
 	writemsr(MSR_FSBASE, (u32_t)(addr), (u32_t)((addr) >> 32));
 }
 


### PR DESCRIPTION
### Summary of this Pull Request (PR)

We already have updating tls logic when thread switches. Thus the only problem here is to remove save & restore %fs an %gs registers in `entry.S`. Also, in order to keep the `pt_regs` struct original logic, we can simply add & sub %rsp when there is an exception, no need to to push and pop. This will also fix that print regs problem, now it can correctly print all registers when there is a BUG()/assert().

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [x] unit_pingpong
- [ ] unit_schedtests
- [ ] ...(add others here)
