### PR TITLE
Addition to the capmgr initargs: the list of components in shared virtual address spaces

### DIFF
--- a/src/components/implementation/capmgr/simple/capmgr.c
+++ b/src/components/implementation/capmgr/simple/capmgr.c
@@ -217,7 +217,7 @@ memmgr_virt_to_phys(vaddr_t vaddr)
 
 	c = ss_comp_get(cos_inv_token());
 	if (!c) return 0;
-	
+
 	return call_cap_op(c->comp.comp_res->ci.pgtbl_cap, CAPTBL_OP_INTROSPECT, (vaddr_t)vaddr, 0, 0, 0);
 }
 
@@ -725,10 +725,28 @@ cos_init(void)
 {
 	struct cos_defcompinfo *defci = cos_defcompinfo_curr_get();
 	struct cos_compinfo    *ci    = cos_compinfo_get(defci);
+	struct initargs curr, comps;
+	struct initargs_iter i;
+	int cont, found_shared = 0;
 	int ret;
 
 	printc("Starting the capability manager.\n");
 	assert(atol(args_get("captbl_end")) >= BOOT_CAPTBL_FREE);
+
+	/* Example code to walk through the components in shared address spaces */
+	printc("Components in shared address spaces: ");
+	ret = args_get_entry("addrspc_shared", &comps);
+	assert(!ret);
+	for (cont = args_iter(&comps, &i, &curr) ; cont ; cont = args_iter_next(&i, &curr)) {
+		compid_t id = atoi(args_value(&curr));
+
+		found_shared = 1;
+		printc("%ld ", id);
+	}
+	if (!found_shared) {
+		printc("none");
+	}
+	printc("\n");
 
 	/* Get our house in order. Initialize ourself and our data-structures */
 	cos_meminfo_init(&(ci->mi), BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);


### PR DESCRIPTION
### Summary of this Pull Request (PR)

- Add the generation of the address space arguments into the composer.
- Add a simple print out as an example of parsing the array of components in the captbl component.

The current thinking is for the ICBs to be created and maintained by the capmgr so that they can be added to with additional thread allocations. The capmgr needs capabilities to the ICBs when creating threads. Thus, this PR simply uses the initargs to pass the components in shared virtual address spaces to the capmgr.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):

@evanstella This PR is dedicated to you ;-)

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

Tested with a composition script with and without shared vas.
