### PR TITLE
composer: skip empty arguemnts

### DIFF
--- a/src/composer/src/pipe.rs
+++ b/src/composer/src/pipe.rs
@@ -6,7 +6,7 @@ pub struct Pipe {
 
 impl Pipe {
     pub fn new(cmd: &str) -> Self {
-        let args: Vec<&str> = cmd.split(' ').collect();
+        let args: Vec<&str> = cmd.split_whitespace().collect();
 
         Self {
             cur: Command::new(args[0])
@@ -22,7 +22,7 @@ impl Pipe {
     }
 
     pub fn next(self, next: &str) -> Self {
-        let args: Vec<&str> = next.split(' ').collect();
+        let args: Vec<&str> = next.split_whitespace().collect();
         let new_cmd = Command::new(args[0])
             .args(&args[1..])
             .stdin(self.cur.stdout.unwrap()) // It's spawned, so it's ok to unwrap


### PR DESCRIPTION
I've messed up in previous patch. .split(' ') splits by exactly one whitespace, which causes compose failure when no optional make arguments provided. Fix it by using proper whitespace parsing API 

I just hope nobody noticed


Signed-off-by: Pavel Skripkin <paskripkin@gmail.com>
