### PR TITLE
address-space identifiers for use in SCB

### DIFF
--- a/src/components/lib/crt/crt.h
+++ b/src/components/lib/crt/crt.h
@@ -91,6 +91,8 @@ struct crt_comp {
 
 	prot_domain_t protdom;
 	capid_t second_lvl_pgtbl_cap;
+
+	u32_t                  vas_id;
 	struct protdom_ns_vas *ns_vas;
 
 };

--- a/src/components/lib/protdom/struct_defs_arch/default/protdom_stuct_def.h
+++ b/src/components/lib/protdom/struct_defs_arch/default/protdom_stuct_def.h
@@ -12,3 +12,4 @@ struct protdom_ns_vas {
 struct protdom_ns_asid {
 	char empty;
 };
+

--- a/src/components/lib/protdom/struct_defs_arch/x86_64/protdom_stuct_def.h
+++ b/src/components/lib/protdom/struct_defs_arch/x86_64/protdom_stuct_def.h
@@ -7,9 +7,9 @@
 #define PROTDOM_MPK_NUM_NAMES 	14
 #define PROTDOM_ASID_NUM_NAMES 	4096
 
-#define PROTDOM_NS_STATE_RESERVED 	1
-#define PROTDOM_NS_STATE_ALLOCATED 1 << 1
-#define PROTDOM_NS_STATE_ALIASED 	1 << 2
+#define PROTDOM_NS_STATE_RESERVED   1
+#define PROTDOM_NS_STATE_ALLOCATED  1 << 1
+#define PROTDOM_NS_STATE_ALIASED    1 << 2
 
 
 struct protdom_vas_name {
@@ -25,10 +25,10 @@ struct protdom_asid_mpk_name {
 
 struct protdom_ns_vas {
 	pgtblcap_t top_lvl_pgtbl;
-	struct protdom_vas_name names[PROTDOM_VAS_NUM_NAMES];
-	struct protdom_ns_vas *parent;
-	u32_t asid_name;
-	struct protdom_asid_mpk_name mpk_names[PROTDOM_MPK_NUM_NAMES];
+	struct     protdom_vas_name names[PROTDOM_VAS_NUM_NAMES];
+	struct     protdom_ns_vas *parent;
+	u32_t      asid_name;
+	struct     protdom_asid_mpk_name mpk_names[PROTDOM_MPK_NUM_NAMES];
 };
 
 struct protdom_ns_asid {

--- a/src/composer/src/resources.rs
+++ b/src/composer/src/resources.rs
@@ -15,7 +15,7 @@ enum CapRes {
     Comp(ComponentId),
 }
 
-const BOOT_CAPTBL_FREE: u32 = 60;
+const BOOT_CAPTBL_FREE: u32 = 52;
 
 // The equivalent of the C __captbl_cap2sz(c)
 fn cap_sz(cap: &CapRes) -> u32 {
@@ -224,15 +224,43 @@ fn capmgr_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {
     // Lets provide information to the capability manager about which
     // components are in shared, and which are in exclusive address
     // spaces.
-    let mut shared_vas = Vec::new();
-    let vas: &dyn OrderedSpecPass = s.get_named();
-    for (_, addrspc) in vas.addrspc_components_shared() {
-        for c in &addrspc.components {
-            // unwrap as every name should be represented (see OrderedSpecpass).
-            let id = vas.rmap().get(&c).unwrap();
-            shared_vas.push(ArgsKV::new_key("_".to_string(), format!("{}", id)));
-        }
-    }
+    let ases = s
+        .get_named()
+        .addrspc_components_shared()
+        .iter()
+        .map(|(id, a)| {
+            ArgsKV::new_arr(id.to_string(), {
+                let mut v = vec![
+                    ArgsKV::new_key("name".to_string(), a.name.clone()),
+                    ArgsKV::new_arr(
+                        "components".to_string(),
+                        a.components
+                            .iter()
+                            .map(|c| {
+                                ArgsKV::new_key(
+                                    "_".to_string(),
+                                    s.get_named().rmap().get(c).unwrap().to_string(),
+                                )
+                            })
+                            .collect(),
+                    ),
+                ];
+                v
+            })
+        })
+        .rev()
+        .collect();
+    let excl_ases = s
+        .get_named()
+        .addrspc_components_exclusive()
+        .iter()
+        .map(|c| {
+            ArgsKV::new_key(
+                "_".to_string(),
+                s.get_named().rmap().get(c).unwrap().to_string(),
+            )
+        })
+        .collect();
 
     cfg.args.push(ArgsKV::new_arr(
         "scheduler_hierarchy".to_string(),
@@ -248,7 +276,13 @@ fn capmgr_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {
         .push(ArgsKV::new_arr("captbl".to_string(), ct_args));
     cfg.args
         .push(ArgsKV::new_arr("names".to_string(), names_args));
-    cfg.args.push(ArgsKV::new_arr("addrspc_shared".to_string(), shared_vas));
+    cfg.args
+        .push(ArgsKV::new_arr(String::from("addrspc_shared"), ases));
+    cfg.args.
+        push(ArgsKV::new_arr(
+        String::from("addrspc_exclusive"),
+        excl_ases,
+    ));
 }
 
 fn constructor_config(s: &SystemState, id: &ComponentId, cfg: &mut CompConfigState) {


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Added identifiers to the crt_comp struct that uniquely identify which VAS a component is in, and updated the composer to provide the capmgr with information it needs to assign the ids.

For pull into beta branch.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
(Specify @<github.com username(s)> of the reviewers. Ex: @user1, @user2)


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [ ] Comments adhere to the Style Guide (SG)
- [ ] Spacing adhere's to the SG
- [ ] Naming adhere's to the SG
- [ ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ ] I've made an attempt to remove all redundant code
- [ ] I've considered ways in which my changes might impact existing code, and cleaned it up
- [ ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ ] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [ ] unit_pingpong
- [ ] unit_schedtests
- [ ] ...(add others here)
