### PR TITLE
Handling of the startup issues related to the CPU features

### DIFF
--- a/src/platform/i386/chal/chal_proto.h
+++ b/src/platform/i386/chal/chal_proto.h
@@ -53,6 +53,8 @@ struct cap_pgtbl {
 	u64_t             frozen_ts; /* timestamp when frozen is set. */
 } __attribute__((packed));
 
+#ifdef MPK_ENABLE
+
 static inline void
 wrpkru(u32_t pkru)
 {
@@ -114,6 +116,15 @@ chal_protdom_read(void)
 
 	return PROTDOM_INIT(asid, mpk_key);
 }
+
+#else /* !MPK_ENABLE */
+static inline void wrpkru(u32_t pkru) {}
+static inline u32_t rdpkru(void) { return 0; }
+static inline u32_t pkru_state(prot_domain_t protdom) { return 0; }
+static inline void chal_protdom_write(prot_domain_t protdom) {}
+static inline prot_domain_t chal_protdom_read(void) { return 0; }
+#endif /* MPK_ENABLE */
+
 
 struct cpu_tlb_asid_map {
 	pgtbl_t mapped_pt[NUM_ASID_MAX];

--- a/src/platform/i386/chal/chal_proto.h
+++ b/src/platform/i386/chal/chal_proto.h
@@ -13,7 +13,7 @@
 #define PGTBL_FLAG_MASK 0xf800000000000fff
 #define PGTBL_FRAME_MASK (~PGTBL_FLAG_MASK)
 #define NUM_ASID_BITS (12)
-#define NUM_ASID_MAX ((1<<NUM_ASID_BITS)-1)
+#define NUM_ASID_MAX ((1 << NUM_ASID_BITS) - 1)
 #define PGTBL_ASID_MASK (0xfff)
 #define CR3_NO_FLUSH (1ul << 63)
 #elif defined(__i386__)
@@ -28,11 +28,11 @@
 #endif
 
 #define PGTBL_ENTRY (1 << PGTBL_ENTRY_ORDER)
-#define SUPER_PAGE_FLAG_MASK  (0x3FFFFF)
-#define SUPER_PAGE_PTE_MASK   (0x3FF000)
+#define SUPER_PAGE_FLAG_MASK (0x3FFFFF)
+#define SUPER_PAGE_PTE_MASK (0x3FF000)
 
 /* FIXME:find a better way to do this */
-#define EXTRACT_SUB_PAGE(super) ((super) & SUPER_PAGE_PTE_MASK)
+#define EXTRACT_SUB_PAGE(super) ((super)&SUPER_PAGE_PTE_MASK)
 
 /* Page table related prototypes & structs */
 /* make it an opaque type...not to be touched */
@@ -58,15 +58,13 @@ struct cap_pgtbl {
 static inline void
 wrpkru(u32_t pkru)
 {
-	asm volatile (
-		"xor %%rcx, %%rcx\n\t"
-		"xor %%rdx, %%rdx\n\t"
-		"mov %0,    %%eax\n\t"
-		"wrpkru\n\t"
-		: 
-		: "r" (pkru)
-		: "eax", "rcx", "rdx"
-	);
+	asm volatile("xor %%rcx, %%rcx\n\t"
+	             "xor %%rdx, %%rdx\n\t"
+	             "mov %0,    %%eax\n\t"
+	             "wrpkru\n\t"
+	             :
+	             : "r"(pkru)
+	             : "eax", "rcx", "rdx");
 }
 
 static inline u32_t
@@ -74,14 +72,12 @@ rdpkru(void)
 {
 	u32_t pkru;
 
-	asm volatile(
-		"xor %%rcx, %%rcx\n\t"
-		"xor %%rdx, %%rdx\n\t"
-		"rdpkru"
-		: "=a" (pkru) 
-		: 
-		: "rcx", "rdx"
-	);
+	asm volatile("xor %%rcx, %%rcx\n\t"
+	             "xor %%rdx, %%rdx\n\t"
+	             "rdpkru"
+	             : "=a"(pkru)
+	             :
+	             : "rcx", "rdx");
 
 	return pkru;
 }
@@ -104,7 +100,7 @@ static inline prot_domain_t
 chal_protdom_read(void)
 {
 	unsigned long cr3;
-	u16_t asid, mpk_key;
+	u16_t         asid, mpk_key;
 
 	u32_t pkru = rdpkru();
 	assert(pkru);
@@ -117,12 +113,30 @@ chal_protdom_read(void)
 	return PROTDOM_INIT(asid, mpk_key);
 }
 
-#else /* !MPK_ENABLED */
-static inline void wrpkru(u32_t pkru) {}
-static inline u32_t rdpkru(void) { return 0; }
-static inline u32_t pkru_state(prot_domain_t protdom) { return 0; }
-static inline void chal_protdom_write(prot_domain_t protdom) {}
-static inline prot_domain_t chal_protdom_read(void) { return 0; }
+#else  /* !MPK_ENABLED */
+static inline void
+wrpkru(u32_t pkru)
+{
+}
+static inline u32_t
+rdpkru(void)
+{
+	return 0;
+}
+static inline u32_t
+pkru_state(prot_domain_t protdom)
+{
+	return 0;
+}
+static inline void
+chal_protdom_write(prot_domain_t protdom)
+{
+}
+static inline prot_domain_t
+chal_protdom_read(void)
+{
+	return 0;
+}
 #endif /* MPK_ENABLED */
 
 
@@ -142,7 +156,7 @@ chal_cached_pt_curr(prot_domain_t protdom)
 static inline void
 chal_cached_pt_update(pgtbl_t pt, prot_domain_t protdom)
 {
-	u16_t asid = PROTDOM_ASID(protdom);
+	u16_t asid                                = PROTDOM_ASID(protdom);
 	tlb_asid_map[get_cpuid()].mapped_pt[asid] = pt;
 }
 
@@ -154,7 +168,7 @@ chal_pgtbl_update(struct pgtbl_info *pt)
 
 	/* lowest 12 bits is the context identifier */
 	unsigned long cr3 = (unsigned long)pt->pgtbl | asid;
-	
+
 	/* fastpath: don't need to invalidate tlb entries; otherwise flush tlb on switch */
 	if (likely(chal_cached_pt_curr(asid) == pt->pgtbl)) {
 		cr3 |= CR3_NO_FLUSH;
@@ -177,4 +191,3 @@ chal_pgtbl_read(void)
 }
 
 #endif /* CHAL_PROTO_H */
-

--- a/src/platform/i386/chal/chal_proto.h
+++ b/src/platform/i386/chal/chal_proto.h
@@ -53,7 +53,7 @@ struct cap_pgtbl {
 	u64_t             frozen_ts; /* timestamp when frozen is set. */
 } __attribute__((packed));
 
-#ifdef MPK_ENABLE
+#ifdef MPK_ENABLED
 
 static inline void
 wrpkru(u32_t pkru)
@@ -117,13 +117,13 @@ chal_protdom_read(void)
 	return PROTDOM_INIT(asid, mpk_key);
 }
 
-#else /* !MPK_ENABLE */
+#else /* !MPK_ENABLED */
 static inline void wrpkru(u32_t pkru) {}
 static inline u32_t rdpkru(void) { return 0; }
 static inline u32_t pkru_state(prot_domain_t protdom) { return 0; }
 static inline void chal_protdom_write(prot_domain_t protdom) {}
 static inline prot_domain_t chal_protdom_read(void) { return 0; }
-#endif /* MPK_ENABLE */
+#endif /* MPK_ENABLED */
 
 
 struct cpu_tlb_asid_map {

--- a/src/platform/i386/chal/shared/cos_config.h
+++ b/src/platform/i386/chal/shared/cos_config.h
@@ -80,6 +80,9 @@
 #define SCHED_PRINTOUT_PERIOD 100000
 #define COMPONENT_ASSERTIONS 1 // activate assertions in components?
 
+/* Optional CPU features */
+// #define MPK_ENABLED
+
 #define FPU_ENABLED 1
 #define FPU_SUPPORT_SSE 1
 #define FPU_SUPPORT_FXSR 1 /* >0 : CPU supports FXSR. */

--- a/src/platform/i386/chal/shared/cos_config.h
+++ b/src/platform/i386/chal/shared/cos_config.h
@@ -24,12 +24,12 @@
  * FIXME: The macro to set a portion of memory of the booter to super pages -
  * should be dynamically passed from kernel to userlevel!
  */
-#define NUM_SUPERPAGES           139
-#define MAX_USABLE_MEMORY        1700
+#define NUM_SUPERPAGES 139
+#define MAX_USABLE_MEMORY 1700
 /* FIXME: This is a hack - was 0xD800000, now expanded to 1200MB */
-#define EXTRA_MEMORY             ((MAX_USABLE_MEMORY - 512) << 20)
-#define EXTRA_SUPERPAGES         ((MAX_USABLE_MEMORY - 808) / 4)
-#define TOTAL_SUPERPAGES         (NUM_SUPERPAGES + EXTRA_SUPERPAGES - 1)
+#define EXTRA_MEMORY ((MAX_USABLE_MEMORY - 512) << 20)
+#define EXTRA_SUPERPAGES ((MAX_USABLE_MEMORY - 808) / 4)
+#define TOTAL_SUPERPAGES (NUM_SUPERPAGES + EXTRA_SUPERPAGES - 1)
 
 /*
  * 1 MB, note that this is not the PA of kernel-usable memory, instead
@@ -42,7 +42,10 @@
 #else
 #define COS_MEM_KERN_PA_ORDER (29)
 #endif
-#define COS_MEM_KERN_PA_SZ ((1UL << COS_MEM_KERN_PA_ORDER) - (1UL << 26)) /* FIXME: Need a way to get physical memory size from kernel. Cannot use a hardcoded value, actual memory could be much lower! */
+#define COS_MEM_KERN_PA_SZ                                                                                          \
+	((1UL << COS_MEM_KERN_PA_ORDER)                                                                             \
+	 - (1UL << 26)) /* FIXME: Need a way to get physical memory size from kernel. Cannot use a hardcoded value, \
+	                   actual memory could be much lower! */
 
 #define COS_MEM_COMP_START_VA ((1 << 30) + (1 << 22)) /* 1GB + 4MB (a relic) */
 
@@ -58,10 +61,10 @@
 #define COS_HW_MMIO_MAX_SZ (1UL << 27) /* Assuming a MAX of 128MB for MMIO. */
 #if defined(__x86_64__)
 #define COS_PHYMEM_MAX_SZ ((1UL << 35) - (1UL << 22) - COS_HW_MMIO_MAX_SZ) /* 1GB - 4MB - MMIO sz */
-#define COS_PHYMEM_END_PA ((1UL << 35) - COS_HW_MMIO_MAX_SZ) /* Maximum usable physical memory */
+#define COS_PHYMEM_END_PA ((1UL << 35) - COS_HW_MMIO_MAX_SZ)               /* Maximum usable physical memory */
 #else
 #define COS_PHYMEM_MAX_SZ ((1UL << 30) - (1UL << 22) - COS_HW_MMIO_MAX_SZ) /* 1GB - 4MB - MMIO sz */
-#define COS_PHYMEM_END_PA ((1UL << 30) - COS_HW_MMIO_MAX_SZ) /* Maximum usable physical memory */
+#define COS_PHYMEM_END_PA ((1UL << 30) - COS_HW_MMIO_MAX_SZ)               /* Maximum usable physical memory */
 #endif
 
 
@@ -146,38 +149,38 @@
 #define COS_PGTBL_ORDER_PTE_0 39
 
 /* Page sizes */
-#define COS_PGTBL_NUM_ORDER      2
-#define COS_PGTBL_ORDERS_64         COS_PGTBL_ORDER_PTE_3, COS_PGTBL_ORDER_PTE_2, COS_PGTBL_ORDER_PTE_1, COS_PGTBL_ORDER_PTE_0
+#define COS_PGTBL_NUM_ORDER 2
+#define COS_PGTBL_ORDERS_64 COS_PGTBL_ORDER_PTE_3, COS_PGTBL_ORDER_PTE_2, COS_PGTBL_ORDER_PTE_1, COS_PGTBL_ORDER_PTE_0
 #define COS_PGTBL_ORDER2POS_64 /* 0/1B    1/2B    2/4B    3/8B   4/16B   5/32B   6/64B  7/128B  8/256B  9/512B */ \
-                               -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */ \
-                               -1,     -1,      4,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */ \
-                               -1,     3,     1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 30/1G   31/2G  32/4G   33/8G   34/16G   35/32G   36/64G   37/128G   38/256G   39/512G */ \
-                                2,     -1,     -1,      -1,     -1,      -1,      -1,      -1,       -1,      1       \
+	-1, -1, -1, -1, -1, -1, -1, -1, -1,                                                                       \
+	  -1, /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */                 \
+	  -1, -1, 4, -1, -1, -1, -1, -1, -1,                                                                      \
+	  -1, /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */                 \
+	  -1, 3, 1, -1, -1, -1, -1, -1, -1,                                                                       \
+	  -1, /* 30/1G   31/2G  32/4G   33/8G   34/16G   35/32G   36/64G   37/128G   38/256G   39/512G */         \
+	  2, -1, -1, -1, -1, -1, -1, -1, -1, 1
 
-/* FIXME: we need to remove this x86_32 pgtbl definitions, now we keep it here simply because retype memory logic heavily rely on it */
+/* FIXME: we need to remove this x86_32 pgtbl definitions, now we keep it here simply because retype memory logic
+ * heavily rely on it */
 #define COS_PGTBL_ORDER_PTE 12
 #define COS_PGTBL_ORDER_PGD 22
 
-#define COS_PGTBL_ORDERS         COS_PGTBL_ORDER_PTE, COS_PGTBL_ORDER_PGD
+#define COS_PGTBL_ORDERS COS_PGTBL_ORDER_PTE, COS_PGTBL_ORDER_PGD
 #define COS_PGTBL_ORDER2POS /* 0/1B    1/2B    2/4B    3/8B   4/16B   5/32B   6/64B  7/128B  8/256B  9/512B */ \
-                               -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */ \
-                               -1,     -1,      0,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */ \
-                               -1,     -1,     1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 30/1G   31/2G */ \
-                               -1,     -1 \
+	-1, -1, -1, -1, -1, -1, -1, -1, -1,                                                                    \
+	  -1, /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */              \
+	  -1, -1, 0, -1, -1, -1, -1, -1, -1,                                                                   \
+	  -1, /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */              \
+	  -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, /* 30/1G   31/2G */                                           \
+	  -1, -1
 
 /* PTE user pagetable modifiable flags */
 #define COS_PAGE_READABLE (0)
 #define COS_PAGE_WRITABLE (1ul << 1)
-#define COS_PAGE_PKEY0    (1ul << 59)
-#define COS_PAGE_PKEY1    (1ul << 60)
-#define COS_PAGE_PKEY2    (1ul << 61)
-#define COS_PAGE_PKEY3    (1ul << 62)
+#define COS_PAGE_PKEY0 (1ul << 59)
+#define COS_PAGE_PKEY1 (1ul << 60)
+#define COS_PAGE_PKEY2 (1ul << 61)
+#define COS_PAGE_PKEY3 (1ul << 62)
 #define COS_PAGE_XDISABLE (1ul << 63)
 
 #elif defined(__i386__)
@@ -186,17 +189,15 @@
 #define COS_PGTBL_ORDER_PGD 22
 
 /* Page sizes */
-#define COS_PGTBL_NUM_ORDER      2
-#define COS_PGTBL_ORDERS         COS_PGTBL_ORDER_PTE, COS_PGTBL_ORDER_PGD
+#define COS_PGTBL_NUM_ORDER 2
+#define COS_PGTBL_ORDERS COS_PGTBL_ORDER_PTE, COS_PGTBL_ORDER_PGD
 #define COS_PGTBL_ORDER2POS /* 0/1B    1/2B    2/4B    3/8B   4/16B   5/32B   6/64B  7/128B  8/256B  9/512B */ \
-                               -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */ \
-                               -1,     -1,      0,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */ \
-                               -1,     -1,     1,     -1,     -1,     -1,     -1,     -1,     -1,     -1, \
-                            /* 30/1G   31/2G */ \
-                               -1,     -1 \
-/* PTE user modifiable flags */
+	-1, -1, -1, -1, -1, -1, -1, -1, -1,                                                                    \
+	  -1, /* 10/1K   11/2K   12/4K   13/8K  14/16K  15/32K  16/64K 17/128K 18/256K 19/512K */              \
+	  -1, -1, 0, -1, -1, -1, -1, -1, -1,                                                                   \
+	  -1, /* 20/1M   21/2M   22/4M   23/8M  24/16M  25/32M  26/64M 27/128M 28/256M 29/512M */              \
+	  -1, -1, 1, -1, -1, -1, -1, -1, -1, -1, /* 30/1G   31/2G */                                           \
+	  -1, -1                                 /* PTE user modifiable flags */
 #define COS_PAGE_READABLE (0)
 #define COS_PAGE_WRITABLE (1ul << 1)
 

--- a/src/platform/i386/chal_cpu.h
+++ b/src/platform/i386/chal_cpu.h
@@ -195,8 +195,26 @@ chal_cpu_init(void)
 	u32_t a = 0, b = 0, c = 0, d = 0;
 	word_t cr0;
 
+	a = 0x07;
+	c = 0;
+	chal_cpuid(&a, &b, &c, &d);
+	if (c & (1 << 3)) {
+		cr4 |= CR4_PKE;
+		printk("CPU supports MPK: enabling.\n");
+#ifndef MPK_ENABLE
+		printk("ERROR: CPU supports MPK, but not enabled in build system. Please set MPK_ENABLE.\n");
+		assert(0);
+#endif
+	} else {
+		printk("CPU does NOT support MPK: not enabling.\n");
+#ifdef MPK_ENABLE
+		printk("ERROR: MPK not supported by hardware, but enabled in build system. Please unset MPK_ENABLE.");
+		assert(0);
+#endif
+	}
+
 	/* CR4_OSXSAVE has to be set to enable xgetbv/xsetbv */
-	chal_cpu_cr4_set(cr4 | CR4_PSE | CR4_PGE | CR4_OSXSAVE | CR4_PKE | CR4_PCIDE);
+	chal_cpu_cr4_set(cr4 | CR4_PSE | CR4_PGE | CR4_OSXSAVE | CR4_PCIDE);
 
 	/* I'm not sure this is the best spot for this */
 	assert(sizeof(struct ulk_invstk) == ULK_INVSTK_SZ);

--- a/src/platform/i386/chal_cpu.h
+++ b/src/platform/i386/chal_cpu.h
@@ -7,26 +7,29 @@
 #include "isr.h"
 #include "tss.h"
 
-typedef enum {
-	CR0_PE    = 1 << 0,  /* Protected Mode Enable */
-	CR0_MP    = 1 << 1,  /* Monitor co-processor */
-	CR0_EM    = 1 << 2,  /* Emulation x87 FPU */
-	CR0_TS    = 1 << 3,  /* Task switched */
-	CR0_ET    = 1 << 4,  /* Extension type */
-	CR0_NE    = 1 << 5,  /* Numeric error */
-	CR0_WP    = 1 << 16, /* Write protect */
-	CR0_AM    = 1 << 18, /* Alignment mask */
-	CR0_NW    = 1 << 29, /* Not-write through */
-	CR0_CD    = 1 << 30, /* Cache disable */
-	CR0_PG    = 1 << 31  /* Paging */
+typedef enum
+{
+	CR0_PE = 1 << 0,  /* Protected Mode Enable */
+	CR0_MP = 1 << 1,  /* Monitor co-processor */
+	CR0_EM = 1 << 2,  /* Emulation x87 FPU */
+	CR0_TS = 1 << 3,  /* Task switched */
+	CR0_ET = 1 << 4,  /* Extension type */
+	CR0_NE = 1 << 5,  /* Numeric error */
+	CR0_WP = 1 << 16, /* Write protect */
+	CR0_AM = 1 << 18, /* Alignment mask */
+	CR0_NW = 1 << 29, /* Not-write through */
+	CR0_CD = 1 << 30, /* Cache disable */
+	CR0_PG = 1 << 31  /* Paging */
 } cr0_flags_t;
 
-typedef enum {
-	CR4_TSD        = 1 << 2,  /* time stamp (rdtsc) access at user-level disabled */
-	CR4_PSE        = 1 << 4,  /* page size extensions (superpages) */
-	CR4_PGE        = 1 << 7,  /* page global bit enabled */
-	CR4_PCE        = 1 << 8,  /* user-level access to performance counters enabled (rdpmc) */
-	CR4_OSFXSR     = 1 << 9,  /* if set, enable SSE instructions and fast FPU save & restore, or using SSE instructions will cause #UD */
+typedef enum
+{
+	CR4_TSD    = 1 << 2, /* time stamp (rdtsc) access at user-level disabled */
+	CR4_PSE    = 1 << 4, /* page size extensions (superpages) */
+	CR4_PGE    = 1 << 7, /* page global bit enabled */
+	CR4_PCE    = 1 << 8, /* user-level access to performance counters enabled (rdpmc) */
+	CR4_OSFXSR = 1 << 9, /* if set, enable SSE instructions and fast FPU save & restore, or using SSE instructions
+	                        will cause #UD */
 	CR4_OSXMMEXCPT = 1 << 10, /* Operating System Support for Unmasked SIMD Floating-Point Exceptions */
 	CR4_FSGSBASE   = 1 << 16, /* user level fs/gs access permission bit */
 	CR4_PCIDE      = 1 << 17, /* Process Context Identifiers Enable*/
@@ -36,17 +39,19 @@ typedef enum {
 	CR4_PKE        = 1 << 22  /* MPK Support */
 } cr4_flags_t;
 
-typedef enum {
-	XCR0    = 0,  /* XCR0 register */
+typedef enum
+{
+	XCR0 = 0, /* XCR0 register */
 } xcr_regs_t;
 
-typedef enum {
-	XCR0_x87      = 1 << 0,  /* X87(must be 1) */
-	XCR0_SSE      = 1 << 1,  /* SSE enable */
-	XCR0_AVX      = 1 << 2,  /* AVX enable */
+typedef enum
+{
+	XCR0_x87 = 1 << 0, /* X87(must be 1) */
+	XCR0_SSE = 1 << 1, /* SSE enable */
+	XCR0_AVX = 1 << 2, /* AVX enable */
 } xcr0_flags_t;
 
-static inline word_t 
+static inline word_t
 chal_cpu_cr0_get(void)
 {
 	word_t config;
@@ -89,12 +94,10 @@ chal_cpu_cr4_set(cr4_flags_t flags)
 static inline u64_t
 chal_cpu_xgetbv(u32_t xcr_n)
 {
-	u32_t low, high; 
+	u32_t low, high;
 	u64_t ret;
 
-	asm volatile(
-		"xgetbv\n\t"
-		:"=a"(low),"=d"(high) : "c"(xcr_n));
+	asm volatile("xgetbv\n\t" : "=a"(low), "=d"(high) : "c"(xcr_n));
 
 	ret = ((u64_t)high << 32) | low;
 	return ret;
@@ -107,9 +110,7 @@ chal_cpu_xsetbv(u32_t xcr_n, u64_t config)
 	low  = (u32_t)config;
 	high = config >> 32;
 
-	asm volatile(
-		"xsetbv\n\t" \
-		::"a"(low), "d"(high), "c"(xcr_n));
+	asm volatile("xsetbv\n\t" ::"a"(low), "d"(high), "c"(xcr_n));
 }
 
 static inline void
@@ -126,7 +127,6 @@ chal_cpu_eflags_init(void)
 	val |= 3 << 12; /* iopl */
 	asm volatile("pushl %0 ; popf" : : "r"(val));
 #endif
-
 }
 
 static inline void
@@ -139,22 +139,22 @@ chal_cpu_pgtbl_activate(pgtbl_t pgtbl)
 #endif
 }
 
-#define IA32_SYSENTER_CS  0x174
+#define IA32_SYSENTER_CS 0x174
 #define IA32_SYSENTER_ESP 0x175
 #define IA32_SYSENTER_EIP 0x176
 #define MSR_PLATFORM_INFO 0x000000ce
-#define MSR_APIC_BASE     0x1b
-#define MSR_TSC_AUX       0xc0000103
+#define MSR_APIC_BASE 0x1b
+#define MSR_TSC_AUX 0xc0000103
 
 #if defined(__x86_64__)
-#define MSR_IA32_EFER		0xC0000080
-#define MSR_STAR 		0xC0000081 
-#define MSR_LSTAR 		0xC0000082
-#define MSR_SFMASK 		0xC0000084
+#define MSR_IA32_EFER 0xC0000080
+#define MSR_STAR 0xC0000081
+#define MSR_LSTAR 0xC0000082
+#define MSR_SFMASK 0xC0000084
 
-#define MSR_FSBASE		0xC0000100
-#define MSR_USER_GSBASE 	0xC0000101
-#define MSR_KERNEL_GSBASE 	0xC0000102
+#define MSR_FSBASE 0xC0000100
+#define MSR_USER_GSBASE 0xC0000101
+#define MSR_KERNEL_GSBASE 0xC0000102
 #endif
 
 extern void sysenter_entry(void);
@@ -186,21 +186,20 @@ chal_cpu_coreid_set(u32_t coreid)
 static void
 chal_cpu_init(void)
 {
-	unsigned long cr4 = chal_cpu_cr4_get();
-	cpuid_t cpu_id = get_cpuid();
+	unsigned long cr4    = chal_cpu_cr4_get();
+	cpuid_t       cpu_id = get_cpuid();
 
 #if defined(__x86_64__)
-	u32_t low = 0, high = 0;
-	u64_t xcr0_config = 0;
-	u32_t a = 0, b = 0, c = 0, d = 0;
+	u32_t  low = 0, high = 0;
+	u64_t  xcr0_config = 0;
+	u32_t  a = 0, b = 0, c = 0, d = 0;
 	word_t cr0;
 
 	a = 0x1;
 	chal_cpuid(&a, &b, &c, &d);
 
 #ifdef MPK_ENABLED
-	if(c & CR4_PKE)
-	{
+	if (c & CR4_PKE) {
 		printk("The CPU supports PKE, enabling...\n");
 		cr4 |= CR4_PKE;
 	} else {
@@ -209,17 +208,15 @@ chal_cpu_init(void)
 	}
 #endif
 
-	if(c & CR4_PCIDE)
-	{
+	if (c & CR4_PCIDE) {
 		cr4 |= CR4_PCIDE;
 	} else {
-
-	/* 
-	 * To address the issue where INVLPG may not properly 
-	 * flush Global entries on CPUs when PCIDs are enabled, 
-	 * Linux disabled PCID for certain Intel CPUs. 
-	 * Composite does not use INVLPG feature.
-	 */
+		/*
+		 * To address the issue where INVLPG may not properly
+		 * flush Global entries on CPUs when PCIDs are enabled,
+		 * Linux disabled PCID for certain Intel CPUs.
+		 * Composite does not use INVLPG feature.
+		 */
 		printk("ERROR: PCID is not supported.\n");
 		assert(0);
 	}
@@ -269,7 +266,7 @@ chal_cpu_init(void)
 	/* Now enable SSE and AVX in XCR0, so that XSAVE features can be used */
 
 	/* 1. Enable SSE */
-	cr0  = chal_cpu_cr0_get();
+	cr0 = chal_cpu_cr0_get();
 	cr0 &= ~((word_t)(CR0_EM)); /* clear EM bit*/
 	cr0 |= (word_t)(CR0_MP);    /* set MP bit */
 	chal_cpu_cr0_set(cr0);
@@ -281,13 +278,14 @@ chal_cpu_init(void)
 	chal_cpu_xsetbv(XCR0, xcr0_config);
 
 	readmsr(MSR_IA32_EFER, &low, &high);
-	writemsr(MSR_IA32_EFER,low | 0x1, high);
+	writemsr(MSR_IA32_EFER, low | 0x1, high);
 
 	writemsr(MSR_STAR, 0, SEL_KCSEG | ((SEL_UCSEG - 16) << 16));
 	writemsr(MSR_LSTAR, (u32_t)((u64_t)sysenter_entry), (u32_t)((u64_t)sysenter_entry >> 32));
 	writemsr(MSR_SFMASK, 512, 0);
 	writemsr(MSR_USER_GSBASE, 0, 0);
-	writemsr(MSR_KERNEL_GSBASE, (u32_t)((u64_t)(&kernel_stack_info[cpu_id])), (u32_t)((u64_t)(&kernel_stack_info[cpu_id]) >> 32));
+	writemsr(MSR_KERNEL_GSBASE, (u32_t)((u64_t)(&kernel_stack_info[cpu_id])),
+	         (u32_t)((u64_t)(&kernel_stack_info[cpu_id]) >> 32));
 
 #elif defined(__i386__)
 	chal_cpu_cr4_set(cr4 | CR4_PSE | CR4_PGE);
@@ -332,7 +330,9 @@ chal_user_upcall(void *ip, u16_t tid, u16_t cpuid)
 #if defined(__x86_64__)
 	/* rcx = user-level ip, r12 = option, rbx = arg, rax = tid + cpuid  */
 	/* $0x3200 : enable interrupt, and iopl is set to 3, the same as user's CPL */
-	__asm__("movq $0x3200, %%r11 ; mov %%rdx, %%ds ; movq %3, %%r12 ; sysretq" : : "c"(ip), "a"(tid | (cpuid << 16)), "d"(SEL_UDSEG), "i"(0), "b"(0));
+	__asm__("movq $0x3200, %%r11 ; mov %%rdx, %%ds ; movq %3, %%r12 ; sysretq"
+	        :
+	        : "c"(ip), "a"(tid | (cpuid << 16)), "d"(SEL_UDSEG), "i"(0), "b"(0));
 #elif defined(__i386__)
 	/* edx = user-level ip, ecx = option, ebx = arg, eax = tid + cpuid */
 	__asm__("sti ; sysexit" : : "c"(0), "d"(ip), "b"(0), "a"(tid | (cpuid << 16)));


### PR DESCRIPTION
### Summary of this Pull Request (PR)

- Disabled MPK (using MPK_ENABLED compile switch) on the main branch. 
- Added a check for PCID support to generate more meaningful error.

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory): @gparmer @WenyuanShao 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [ ] Naming adhere's to the SG
- [ ] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [x] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [ ] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [ ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter (corresponding toml file?)
- [x] unit_pingpong (with sched_pingpong.toml PASSED, ping_pong.toml fails on main)
- [x] unit_schedtests (with sched.toml)
- [x] pingpong with/wo MPK_ENABLED, with/wo CPU pcid support.

Testing environment is my laptop using qemu.
